### PR TITLE
Simplify downloading .protos from other branches

### DIFF
--- a/proto-downloader/download-bisq-protos.sh
+++ b/proto-downloader/download-bisq-protos.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-echo "Downloading Bisq protobuf files from github to $PROTO_PATH directory..."
+# Download Bisq's protobuf definition files.
+# Change the REPO_OWNER and REPO_BRANCH vars if you (developer) need to download from an alternative repo and branch.
+
+REPO_OWNER="bisq-network"
+REPO_BRANCH="master"
+REPO_PROTO_DIR_URL="https://raw.githubusercontent.com/$REPO_OWNER/bisq/$REPO_BRANCH/proto/src/main/proto"
+
+echo "Downloading Bisq protobuf files from $REPO_PROTO_DIR_URL to $PROTO_PATH directory..."
 echo "You can skip this step and copy your own local .proto files instead."
 
-# Download the Bisq master branch's protobuf definition files.
-curl -o ./pb.proto https://raw.githubusercontent.com/bisq-network/bisq/master/proto/src/main/proto/pb.proto
-curl -o ./grpc.proto https://raw.githubusercontent.com/bisq-network/bisq/master/proto/src/main/proto/grpc.proto
+curl -o ./pb.proto "$REPO_PROTO_DIR_URL"/pb.proto
+curl -o ./grpc.proto "$REPO_PROTO_DIR_URL"/grpc.proto
 
 echo "Copying proto files to the Java examples project."
 cp -v *.proto ../java-examples/src/main/proto


### PR DESCRIPTION
Make it easier to download Bisq repo .proto files from different branches.

Based on `main`.