### PR TITLE
Add API ref examples for new getnetwork, getavgbsqprice methods

### DIFF
--- a/cli-examples/GetAverageBsqPrice.sh
+++ b/cli-examples/GetAverageBsqPrice.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source "env.sh"
+$BISQ_HOME/bisq-cli --password=xyz --port=9998 getavgbsqprice --days=30

--- a/cli-examples/GetNetwork.sh
+++ b/cli-examples/GetNetwork.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source "env.sh"
+$BISQ_HOME/bisq-cli --password=xyz --port=9998 getnetwork

--- a/java-examples/src/main/java/bisq/rpccalls/GetAverageBsqPrice.java
+++ b/java-examples/src/main/java/bisq/rpccalls/GetAverageBsqPrice.java
@@ -1,0 +1,28 @@
+package bisq.rpccalls;
+
+import bisq.proto.grpc.GetAverageBsqTradePriceRequest;
+import bisq.proto.grpc.PriceGrpc;
+import io.grpc.ManagedChannelBuilder;
+
+import static java.lang.String.format;
+import static java.lang.System.out;
+
+public class GetAverageBsqPrice extends BaseJavaExample {
+
+    public static void main(String[] args) {
+        try {
+            var channel = ManagedChannelBuilder.forAddress("localhost", 9998).usePlaintext().build();
+            addChannelShutdownHook(channel);
+            var credentials = buildCallCredentials(getApiPassword());
+            var stub = PriceGrpc.newBlockingStub(channel).withCallCredentials(credentials);
+            var request = GetAverageBsqTradePriceRequest.newBuilder().setDays(30).build();
+            var reply = stub.getAverageBsqTradePrice(request);
+            var price = reply.getPrice();
+            out.println(format("30-day avg BTC price: %s, 30-day avg USD price: %s",
+                    price.getBtcPrice(),
+                    price.getUsdPrice()));
+        } catch (Throwable t) {
+            handleError(t);
+        }
+    }
+}

--- a/java-examples/src/main/java/bisq/rpccalls/GetNetwork.java
+++ b/java-examples/src/main/java/bisq/rpccalls/GetNetwork.java
@@ -1,0 +1,24 @@
+package bisq.rpccalls;
+
+import bisq.proto.grpc.GetNetworkRequest;
+import bisq.proto.grpc.WalletsGrpc;
+import io.grpc.ManagedChannelBuilder;
+
+import static java.lang.System.out;
+
+public class GetNetwork extends BaseJavaExample {
+
+    public static void main(String[] args) {
+        try {
+            var channel = ManagedChannelBuilder.forAddress("localhost", 9998).usePlaintext().build();
+            addChannelShutdownHook(channel);
+            var credentials = buildCallCredentials(getApiPassword());
+            var stub = WalletsGrpc.newBlockingStub(channel).withCallCredentials(credentials);
+            var request = GetNetworkRequest.newBuilder().build();
+            var reply = stub.getNetwork(request);
+            out.println(reply.getNetwork());
+        } catch (Throwable t) {
+            handleError(t);
+        }
+    }
+}

--- a/python-examples/bisq/rpccalls/get_average_bsq_price.py
+++ b/python-examples/bisq/rpccalls/get_average_bsq_price.py
@@ -1,0 +1,24 @@
+import grpc
+
+# from getpass import getpass
+import bisq.api.grpc_pb2 as bisq_messages
+import bisq.api.grpc_pb2_grpc as bisq_service
+import grpc
+
+
+def main():
+    grpc_channel = grpc.insecure_channel('localhost:9998')
+    grpc_service_stub = bisq_service.PriceStub(grpc_channel)
+    api_password: str = 'xyz'  # getpass("Enter API password: ")
+    try:
+        response = grpc_service_stub.GetAverageBsqTradePrice.with_call(
+            bisq_messages.GetAverageBsqTradePriceRequest(days=30),
+            metadata=[('password', api_password)])
+        price = response[0].price
+        print('Response: ' + '30-day BTC price: ' + price.btc_price + '  30-day USD price: ' + price.usd_pricez)
+    except grpc.RpcError as rpc_error:
+        print('gRPC API Exception: %s', rpc_error)
+
+
+if __name__ == '__main__':
+    main()

--- a/python-examples/bisq/rpccalls/get_network.py
+++ b/python-examples/bisq/rpccalls/get_network.py
@@ -1,0 +1,22 @@
+import grpc
+
+# from getpass import getpass
+import bisq.api.grpc_pb2 as bisq_messages
+import bisq.api.grpc_pb2_grpc as bisq_service
+
+
+def main():
+    grpc_channel = grpc.insecure_channel('localhost:9998')
+    grpc_service_stub = bisq_service.WalletsStub(grpc_channel)
+    api_password: str = 'xyz'  # getpass("Enter API password: ")
+    try:
+        response = grpc_service_stub.GetNetwork.with_call(
+            bisq_messages.GetNetworkRequest(),
+            metadata=[('password', api_password)])
+        print('Response: ' + response[0].network)
+    except grpc.RpcError as rpc_error:
+        print('gRPC API Exception: %s', rpc_error)
+
+
+if __name__ == '__main__':
+    main()

--- a/reference-doc-builder/src/main/java/bisq/apidoc/BisqApiDocMain.java
+++ b/reference-doc-builder/src/main/java/bisq/apidoc/BisqApiDocMain.java
@@ -125,7 +125,7 @@ public class BisqApiDocMain {
 
         OptionSpec<String> protosInOpt = optionParser.accepts("protosIn", "directory path to input protobuf files")
                 .withRequiredArg()
-                .defaultsTo("src/main/resources/proto");
+                .defaultsTo("java-examples/src/main/proto");
         OptionSpec<String> markdownOutOpt = optionParser.accepts("markdownOut", "directory path to output markdown file")
                 .withRequiredArg()
                 .defaultsTo("./");


### PR DESCRIPTION
Also fixed the default path to java-examples proto files for doc generator's `protosInOpt`.

Based on `main`.