### PR TITLE
Refactor, document Java  API takeoffer bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,23 @@ client example code, and developing new Java and Python clients and bots.
 
 It contains four subprojects:
 
-1. [reference-doc-builder](https://github.com/bisq-network/bisq-api-reference/tree/main/reference-doc-builder) -- The Java
-   application that produces the [API Reference](https://bisq-network.github.io/slate) content, from Bisq protobuf
+1. [reference-doc-builder](https://github.com/bisq-network/bisq-api-reference/tree/main/reference-doc-builder) -- The
+   Java application that produces the [API Reference](https://bisq-network.github.io/slate) content, from Bisq protobuf
    definition files.
 2. [cli-examples](https://github.com/bisq-network/bisq-api-reference/tree/main/cli-examples) -- A folder of bash scripts
    demonstrating how to run API CLI commands. Each script is named for the RPC method call being demonstrated.
 3. [java-examples](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples) -- A Java project
-   demonstrating how to call the API from Java gRPC clients. Each class in
-   the [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/rpccalls)
-   package is named for the RPC method call being demonstrated.
-4. [python-examples](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples) -- A Python3 project
+   demonstrating how to call the API from Java gRPC clients. Each class in the
+   [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/rpccalls)
+   package is named for the RPC method call being demonstrated. There are also some mainnet-ready Java API bots in the
+   [bisq.bots](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/bots)
+   package.
+5. [python-examples](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples) -- A Python3 project
    demonstrating how to call the API from Python3 gRPC clients. Each class in
-   the  [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/rpccalls) package
-   is named for the RPC method call being demonstrated. There are also some simple bot examples in
-   the [bisq.bots](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/bots) package.
+   the  [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/rpccalls)
+   package is named for the RPC method call being demonstrated. There are also some simple (not-ready-for-mainnet) bot
+   examples in the [bisq.bots](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/bots)
+   package.
 
 The RPC method examples are also displayed in the [API Reference](https://bisq-network.github.io/slate). While
 navigating the RPC method links in the reference's table of contents on the left side of the page, they appear in the

--- a/java-examples/README.md
+++ b/java-examples/README.md
@@ -167,7 +167,7 @@ BSQ Swap offer.
 
 ### [Take Best Priced Offer To Buy Btc](#take-best-priced-offer-to-buy-btc)
 
-**Purpose (Sell High)**
+**Purpose:**  Sell your BTC at a higher fiat price
 
 This bot waits for attractively priced BUY BTC (with fiat) offers to appear, and takes 1 or more of them according to
 the bot's configuration. The bot will consider only those offers created with the same payment method associated with
@@ -202,7 +202,7 @@ $ java -jar take-best-priced-offer-to-buy-btc.jar \
 
 ### [Take Best Priced Offer To Sell Btc](#take-best-priced-offer-to-sell-btc)
 
-**Purpose (Buy Low)**
+**Purpose:**  Buy BTC at a lower fiat price
 
 This bot waits for attractively priced SELL BTC (for fiat) offers to appear, and takes 1 or more of them according to
 the bot's configuration. The bot will consider only those offers created with the same payment method associated with
@@ -238,7 +238,7 @@ $ java -jar take-best-priced-offer-to-sell-btc.jar \
 
 ### [Take Best Priced Offer To Buy Bsq](#take-best-priced-offer-to-buy-bsq)
 
-**Purpose (Sell High)**
+**Purpose:**  Sell your BSQ at a higher BTC price
 
 This bot waits for attractively priced BUY BSQ (with BTC) offers to appear, and takes 1 or more of them according to
 the bot's configuration. The bot will consider only those offers created with the same payment method associated with
@@ -268,7 +268,7 @@ $ java -jar take-best-priced-offer-to-buy-bsq.jar \
 
 ### [Take Best Priced Offer To Sell Bsq](#take-best-priced-offer-to-sell-bsq)
 
-**Purpose (Buy Low)**
+**Purpose:**  Buy BSQ at a lower BTC price
 
 This bot waits for attractively priced SELL BSQ (for BTC) offers to appear, and takes 1 or more of them according to
 the bot's configuration. The bot will consider only those offers created with the same payment method associated with
@@ -298,7 +298,7 @@ $ java -jar take-best-priced-offer-to-sell-bsq.jar \
 
 ### [Take Best Priced Offer To Buy Xmr](#take-best-priced-offer-to-buy-xmr)
 
-**Purpose (Sell High)**
+**Purpose:**  Sell your XMR at a higher BTC price
 
 This bot waits for attractively priced BUY XMR (with BTC) offers to appear, and takes 1 or more of them according to
 the bot's configuration. The bot will consider only those offers created with the same payment method associated with
@@ -328,7 +328,7 @@ $ java -jar take-best-priced-offer-to-buy-xmr.jar \
 
 ### [Take Best Priced Offer To Sell Xmr](#take-best-priced-offer-to-sell-xmr)
 
-**Purpose (Buy Low)**
+**Purpose:**  Buy XMR at a lower BTC price
 
 This bot waits for attractively priced SELL XMR (for BTC) offers to appear, and takes 1 or more of them according to
 the bot's configuration. The bot will consider only those offers created with the same payment method associated with

--- a/java-examples/README.md
+++ b/java-examples/README.md
@@ -39,15 +39,16 @@ some effort into understanding a bot's code and its configuration before trying 
 
 The TakeBestPricedOffer* bots could be combined into a single class, and use multithreaded task scheduling instead of
 loops with Thread sleep instructions, but we want them to be easily understood by people who are not necessarily
-experienced Java coders (and be easily portable to other [gRPC supported language bindings](https://grpc.io/docs/languages)).
-For non-developers, splitting up a one-size-fits-all TakeBestPricedOffer also makes them easier to configure for various
-BTC/Fiat, XMR/BTC, and BSQ/BTC market use cases.
+experienced Java coders (and be easily portable to
+other [gRPC supported language bindings](https://grpc.io/docs/languages)). For non-developers, splitting up a
+one-size-fits-all TakeBestPricedOffer also makes them easier to configure for various BTC/Fiat, XMR/BTC, and BSQ/BTC
+market use cases.
 
 ## [Generating Protobuf Code](#generating-protobuf-code)
 
 ### Download IDL (.proto) Files From The [Bisq Repo](https://github.com/bisq-network/bisq)
 
-The protobuf IDL files are not part of this project, and must be downloaded from the Bisq repository's 
+The protobuf IDL files are not part of this project, and must be downloaded from the Bisq repository's
 [protobuf file directory](https://github.com/bisq-network/bisq/tree/master/proto/src/main/proto).
 
 TODO @ripcurlx, please review https://github.com/ghubstan/bisq-api-reference/pull/11
@@ -78,27 +79,27 @@ the [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main
 package is named for the RPC method call being demonstrated.
 
 Their purpose is to show how to construct a gRPC service method request with parameters, send the request, and print a
-response object if there is one. As a rule, the request is successful if a gRPC StatusRuntimeException is not thrown
-by the API daemon.
+response object if there is one. As a rule, the request is successful if a gRPC StatusRuntimeException is not thrown by
+the API daemon.
 
 Their usage is simple; there are no program arguments for any of them. Just run them with an IDE program launcher or
-your shell.  However, you will usually need to edit the Java class and re-compile it before running it because these 
+your shell. However, you will usually need to edit the Java class and re-compile it before running it because these
 examples know nothing about real Payment Account IDs, Offer IDs, etc. To run the
 [GetOffer.java](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/rpccalls/GetOffer.java)
-example, your will need to change the hard-coded offer ID to a real offer ID to avoid a "not found" gRPC 
+example, your will need to change the hard-coded offer ID to a real offer ID to avoid a "not found" gRPC
 StatusRuntimeException from the API daemon.
 
 ## [Java API Bots](#java-api-bots)
 
 ### Purpose
 
-The Java API bots in this project are meant to be run on mainnet, provide a base for more complex bots, and guide you
-in developing your own bots.
+The Java API bots in this project are meant to be run on mainnet, provide a base for more complex bots, and guide you in
+developing your own bots.
 
-Put some effort into understanding a bot's code and its configuration before trying it on mainnet. While you get 
-familiar with a bot example, you can run it in **dryrun** mode to see how it behaves with different configurations 
-(more later). Even better:  run it while your Bisq API daemons (seednode, arbitration-node, and a trading peer) are 
-connected to a local BTC regtest network. 
+Put some effort into understanding a bot's code and its configuration before trying it on mainnet. While you get
+familiar with a bot example, you can run it in **dryrun** mode to see how it behaves with different configurations
+(more later). Even better:  run it while your Bisq API daemons (seednode, arbitration-node, and a trading peer) are
+connected to a local BTC regtest network.
 The [API test harness](https://github.com/bisq-network/bisq/blob/master/apitest/docs/api-beta-test-guide.md) is
 convenient for this.
 
@@ -131,22 +132,23 @@ To shut down the test harness, enter **^C**.
 
 There are six bots for taking offers:
 
+* [TakeBestPricedOfferToBuyBtc](#take-best-priced-offer-to-buy-btc)
+* [TakeBestPricedOfferToSellBtc](#take-best-priced-offer-to-sell-btc)
+
 * [TakeBestPricedOfferToBuyBsq (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
 * [TakeBestPricedOfferToSellBsq (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
-
-* [TakeBestPricedOfferToBuyBtc (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java)
-* [TakeBestPricedOfferToSellBtc (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
 
 * [TakeBestPricedOfferToBuyXmr (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
 * [TakeBestPricedOfferToSellXmr (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
 
-The **Take Buy/Sell BTC and XMR Offer** bots take 1 or more offers for a given criteria as defined in each bot's 
-configuration file (more later). After the configured maximum number of offers have been taken, the bot shuts down 
-the API daemon and itself because trade payments are made outside Bisq.  Bisq nodes (UI or API) do not communicate
-with your banks and XMR wallets, and *cannot automate fiat and XMR trade payments and deposit confirmations*.
+The **Take Buy/Sell BTC and XMR Offer** bots take 1 or more offers for a given criteria as defined in each bot's
+configuration file (more later). After the configured maximum number of offers have been taken, the bot shuts down the
+API daemon and itself because trade payments are made outside Bisq. Bisq nodes (UI or API) do not communicate with your
+banks and XMR wallets, and *cannot automate fiat and XMR trade payments and deposit confirmations*.
 
-The Bisq trade payment protocol steps of the Bisq protocol can be performed in the UI, or you can finish the trade with 
+The Bisq trade payment protocol steps of the Bisq protocol can be performed in the UI, or you can finish the trade with
 an API daemon and manual CLI commands:
+
 ```asciidoc
 # If you are a BTC buyer, notify peer you have initiated fiat or XMR payment.
 $ ./bisq-cli --password=xyz --port=9998 confirmpaymentstarted --trade-id=<trade-id>
@@ -163,50 +165,70 @@ The **Take Buy/Sell BSQ** bots take 1 or more offers for a given criteria as def
 daemon. BSQ Swaps can be fully automated by the API because the swap transaction is completed within seconds of taking a
 BSQ Swap offer.
 
-#### [TakeBestPricedOfferToSellBtc (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
+### [TakeBestPricedOfferToBuyBtc (From You)](#take-best-priced-offer-to-buy-btc)
 
-**Purpose**
+**Purpose (Sell High)**
 
-This bot waits for attractively priced SELL BTC offers to appear, takes the offers, then shuts down both the API daemon
-and itself (the bot). The user should then proceed to start the desktop UI application and complete the new trades.
+This bot waits for attractively priced BUY BTC (with fiat) offers to appear, and takes 1 or more of them according to
+the bot's configuration. The bot will consider only those offers created with the same payment method associated with
+your bot's configured payment account id.
 
-The benefit this bot provides is freeing up the user time spent watching the offer book in the UI, waiting for the right
-offer to take. Low-priced BTC offers are taken relatively quickly; this bot increases the chance of beating the other
-nodes at taking the offer.
+The benefit this bot provides is freeing up user time spent watching the offer book in the UI, waiting for the right
+offer to take. The disadvantage is having to perform some trade protocol steps outside the API daemon. 
+Fiat payment confirmations must be done as they are when using the Bisq UI -- outside the Bisq application. After bank 
+payments are confirmed in your online banking system, trades can be completed in the desktop UI, or via API CLI commands.
 
-The disadvantage is that if the user takes offers with the API, she must complete the trades with the desktop UI. This
-problem is due to the inability of the API to fully automate every step of the trading protocol. Sending fiat or XMR
-payments, and confirming their receipt, are manual activities performed outside the Bisq daemon and desktop UI.  When you
-switch back and forth between the API daemon and UI, be careful not to let them run at the same time.
+**Warning**
 
-The criteria for determining which offers to take are defined in the bot's configuration file
-TakeBestPricedOfferToSellBtc.properties (located in project's src/main/resources directory). The individual
-configurations are commented in the existing TakeBestPricedOfferToSellBtc.properties, which should be used as a template
-for your own use case.
+Take special care to not run the Bisq API daemon and the desktop application at the same time on the same host.
 
-**Use Cases**
+**Use Cases, Usage and Configuration**
 
-One possible use case for this bot is to buy BTC with GBP, e.g., take a "Faster Payment" offer to sell BTC (to you) for
-GBP at or below the current market GBP price if:
-
-* the offer maker is a preferred trading peer
-* the offer's BTC amount is between 0.10 and 0.25 BTC
-* the current transaction mining fee rate is less than or equal 20 sats / byte
-
-**Usage**
-
-**Configuration**
-
-* Param 1
-* Param 2
-* Param 3
-* ...
+This information is found in
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java)
+.
 
 **Creating And Using Runnable TakeBestPricedOfferToSellBtc Jar**
 
-To create the runnable jar, see [Creating Runnable Jars](#creating-runnable-jars).
+To create a runnable jar, see [Creating Runnable Jars](#creating-runnable-jars). To run the jar, edit the conf file for
+your use case, and use the java -jar command:
 
-To run the jar, edit the conf file for your use case, and run it:
+```asciidoc
+$ java -jar take-best-priced-offer-to-sell-btc.jar \
+    --password=xyz \
+    --dryrun=false \
+    --conf=take-best-priced-offer-to-sell-btc.conf 
+```
+
+### [TakeBestPricedOfferToSellBtc (To You)](#take-best-priced-offer-to-sell-btc)
+
+**Purpose (Buy Low)**
+
+This bot waits for attractively priced SELL BTC (for fiat) offers to appear, and takes 1 or more of them according to
+the bot's configuration. The bot will consider only those offers created with the same payment method associated with
+your bot's configured payment account id.
+
+The benefit this bot provides is freeing up user time spent watching the offer book in the UI, waiting for the right
+offer to take. Low-priced BTC offers are taken relatively quickly; this bot increases the chance of beating other nodes
+to the offer. The disadvantage is having to perform some trade protocol steps outside the API daemon. Fiat 
+payments must be sent as they are when using the Bisq UI -- outside the Bisq application. After bank payments are made
+in your online banking system, trades can be completed in the desktop UI, or via API CLI commands.
+
+**Warning**
+
+Take special care to not run the Bisq API daemon and the desktop application at the same time on the same host.
+
+**Use Cases, Usage and Configuration**
+
+This information is found in
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
+.
+
+**Creating And Using Runnable TakeBestPricedOfferToSellBtc Jar**
+
+To create a runnable jar, see [Creating Runnable Jars](#creating-runnable-jars). To run the jar, edit the conf file for
+your use case, and use the java -jar command:
+
 ```asciidoc
 $ java -jar take-best-priced-offer-to-buy-btc.jar \
     --password=xyz \
@@ -216,12 +238,13 @@ $ java -jar take-best-priced-offer-to-buy-btc.jar \
 
 ### [Creating Runnable Jars](#creating-runnable-jars)
 
-You can create runnable jars for these bots and run them in a terminal.  After building the java-examples project, run
-the script **java-examples/scripts/create-bot-jars.sh**.  You can run the jar from the
-**java-examples/scripts/java-examples** folder created by the script, or copy that folder where you like and run it
-from there.
+You can create runnable jars for these bots and run them in a terminal. After building the java-examples project, run
+the script **java-examples/scripts/create-bot-jars.sh**. You can run the jar from the
+**java-examples/scripts/java-examples** folder created by the script, or copy that folder where you like and run it from
+there.
 
 Here are the steps to create runnable bot jars.
+
 ```asciidoc
 # Build the java-examples project.
 $ cd java-examples
@@ -231,22 +254,20 @@ $ ./gradlew clean build
 $ scripts/create-bot-jars.sh
 ```
 
-Each jar has its own conf file, generated from the bot source code's properties file.  For example,
+Each jar has its own conf file, generated from the bot source code's properties file. For example,
 
-* take-best-priced-offer-to-buy-btc.jar 
+* take-best-priced-offer-to-buy-btc.jar
 * take-best-priced-offer-to-buy-btc.conf
 
 are created from
-* TakeBestPricedOfferToBuyBtc.java 
+
+* TakeBestPricedOfferToBuyBtc.java
 * TakeBestPricedOfferToBuyBtc.properties
 
 To run it, edit the conf file for your use case and run a java -jar command:
 
 ```asciidoc
-$ java -jar take-best-priced-offer-to-buy-btc.jar \
-    --password=xyz \
-    --dryrun=false \
-    --conf=take-best-priced-offer-to-buy-btc.conf 
+$ java -jar take-best-priced-offer-to-sell-btc.jar \ --password=xyz \ --dryrun=false \ --conf=take-best-priced-offer-to-sell-btc.conf 
 ```
 
 You can rename a conf file as you like, and save several copies for specific use cases.

--- a/java-examples/README.md
+++ b/java-examples/README.md
@@ -132,14 +132,15 @@ To shut down the test harness, enter **^C**.
 
 There are six bots for taking offers:
 
-* [TakeBestPricedOfferToBuyBtc](#take-best-priced-offer-to-buy-btc)
-* [TakeBestPricedOfferToSellBtc](#take-best-priced-offer-to-sell-btc)
+* [Take Best Priced Offer To Buy Btc](#take-best-priced-offer-to-buy-btc)
+* [Take Best Priced Offer To Sell Btc](#take-best-priced-offer-to-sell-btc)
 
-* [TakeBestPricedOfferToBuyBsq (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
-* [TakeBestPricedOfferToSellBsq (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
 
-* [TakeBestPricedOfferToBuyXmr (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
-* [TakeBestPricedOfferToSellXmr (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
+* [Take Best Priced Offer To Buy Bsq](#take-best-priced-offer-to-buy-bsq)
+* [Take Best Priced Offer To Sell Bsq](#take-best-priced-offer-to-sell-bsq)
+
+* [Take Best Priced Offer To Buy Xmr](#take-best-priced-offer-to-buy-xmr)
+* [Take Best Priced Offer To Sell Xmr](#take-best-priced-offer-to-sell-xmr)
 
 The **Take Buy/Sell BTC and XMR Offer** bots take 1 or more offers for a given criteria as defined in each bot's
 configuration file (more later). After the configured maximum number of offers have been taken, the bot shuts down the
@@ -165,7 +166,7 @@ The **Take Buy/Sell BSQ** bots take 1 or more offers for a given criteria as def
 daemon. BSQ Swaps can be fully automated by the API because the swap transaction is completed within seconds of taking a
 BSQ Swap offer.
 
-### [TakeBestPricedOfferToBuyBtc (From You)](#take-best-priced-offer-to-buy-btc)
+### [Take Best Priced Offer To Buy Btc](#take-best-priced-offer-to-buy-btc)
 
 **Purpose (Sell High)**
 
@@ -200,7 +201,7 @@ $ java -jar take-best-priced-offer-to-sell-btc.jar \
     --conf=take-best-priced-offer-to-sell-btc.conf 
 ```
 
-### [TakeBestPricedOfferToSellBtc (To You)](#take-best-priced-offer-to-sell-btc)
+### [Take Best Priced Offer To Sell Btc](#take-best-priced-offer-to-sell-btc)
 
 **Purpose (Buy Low)**
 
@@ -236,6 +237,41 @@ $ java -jar take-best-priced-offer-to-buy-btc.jar \
     --conf=take-best-priced-offer-to-buy-btc.conf 
 ```
 
+
+### [Take Best Priced Offer To Buy Bsq](#take-best-priced-offer-to-buy-bsq)
+
+**Use Cases, Usage and Configuration**
+
+This information is found in
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
+.
+
+### [Take Best Priced Offer To Sell Bsq](#take-best-priced-offer-to-sell-bsq)
+
+**Use Cases, Usage and Configuration**
+
+This information is found in
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
+.
+
+### [Take Best Priced Offer To Buy Xmr](#take-best-priced-offer-to-buy-xmr)
+
+**Use Cases, Usage and Configuration**
+
+This information is found in
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
+.
+
+### [Take Best Priced Offer To Sell Xmr](#take-best-priced-offer-to-sell-xmr)
+
+**Use Cases, Usage and Configuration**
+
+This information is found in
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
+.
+
+
+
 ### [Creating Runnable Jars](#creating-runnable-jars)
 
 You can create runnable jars for these bots and run them in a terminal. After building the java-examples project, run
@@ -267,7 +303,10 @@ are created from
 To run it, edit the conf file for your use case and run a java -jar command:
 
 ```asciidoc
-$ java -jar take-best-priced-offer-to-sell-btc.jar \ --password=xyz \ --dryrun=false \ --conf=take-best-priced-offer-to-sell-btc.conf 
+$ java -jar take-best-priced-offer-to-sell-btc.jar \
+    --password=xyz \
+    --dryrun=false \
+    --conf=take-best-priced-offer-to-sell-btc.conf 
 ```
 
 You can rename a conf file as you like, and save several copies for specific use cases.

--- a/java-examples/README.md
+++ b/java-examples/README.md
@@ -1,11 +1,207 @@
-# Bisq API Java Examples
+# Bisq API Java Examples And Bots
 
-This subproject contains Java classes demonstrating API gRPC method calls.
+This subproject contains:
+* [Java API rpc examples](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/rpccalls)
+  demonstrating how to send API gRPC requests, and handle responses.
 
-Each class in
+* [Java API bots](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/bots)
+  to use as is on mainnet, and demonstrate how to write new API bots.  If interested in porting any bot code to
+  other languages supported by [gRPC](https://grpc.io/docs/languages), please use these Java bot examples, not the
+  Python examples.  The Python examples were written by a Python noob, and don't handle errors.
+
+  TODO Add warning about this to Python Examples README.
+
+* A [Gradle build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle)
+  that could be used as a template for your own API bot project.
+
+## Risks And Warnings
+
+### Never Run API Daemon and [Bisq GUI](https://bisq.network) On Same Host At Same Time
+
+The API daemon and the GUI share the same default wallet and connection ports. Beyond inevitable failures due to 
+fighting over the wallet and ports, doing so will probably corrupt your wallet. Before starting the API daemon, 
+make sure your GUI is shut down, and vice-versa. Please back up your mainnet wallet early and often with the GUI.  
+
+TODO Add warning about this to Python Examples README, Api Reference, and Beta Test Guide.
+
+### Go Slow (But Much Faster Than You Click Buttons In The GUI)
+
+[Bisq](https://bisq.network) was designed to respond to manual clicks in the user interface.  It is not a 
+high-throughput, high-performance system supporting atomic transactions.  Care must be taken to avoid 
+problems due to slow wallet updates on your disk, and Tor network latency.  The API daemon enforces limits on request
+frequency via call rate metering, but you cannot assume bots can perform tasks as rapidly as the API daemon's call 
+rate meters allow.
+
+### Run Bots On Mainnet At Your Own Risk
+
+This document would not state "these bots can be run on mainnet, as is" without reasonable confidence on the part of 
+the code's author, but if you do, you do so at your own risk.  Copious details about running them on a local BTC 
+regtest network, running on mainnet in **dryrun** mode, and each bot's configuration is provided in this document.
+Please put some effort into understanding a bot's code and its configuration before trying it on mainnet.
+
+TODO Add warning about this to Python Examples README.
+
+## Generating Protobuf Code
+
+### Download IDL (.proto) Files From The [Bisq Repo](https://github.com/bisq-network/bisq)
+
+The protobuf IDL files are not part of this project, and must be downloaded from the 
+[Bisq repo](https://github.com/bisq-network/bisq/tree/master/proto/src/main/proto).
+
+You can download them by running 
+[this script](https://github.com/bisq-network/bisq-api-reference/blob/main/proto-downloader/download-bisq-protos.sh)
+from your IDE or a shell:
+```asciidoc
+$ proto-downloader/download-bisq-protos.sh
+```
+
+The java-examples [build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle) 
+will generate the code from the downloaded IDL (.proto) files.
+
+You should be able to generate the protobuf Java sources and all Java examples in your IDE.
+
+In a terminal:
+```asciidoc
+$ cd java-examples
+$ ./gradlew clean build
+```
+
+## Java API Method Examples
+
+Each class in 
 the [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/rpccalls)
 package is named for the RPC method call being demonstrated.
 
-The subproject uses a
-a [Gradle build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle), also
-demonstrating how to generate the necessary protobuf classes from the Bisq .proto files.
+Their purpose is to show how to construct a gRPC service method request with parameters, send the
+request, and print a response object if there is one.  As a rule, the request was successful if 
+no gRPC StatusRuntimeException was received from the API daemon.
+
+Their usage is simple;  there are no program arguments for any of them.  Just run them with an IDE
+program launcher or your shell.
+
+However, you will often need to edit the Java class and re-compile it before running it because these
+examples know nothing about real Payment Account IDs, Offer IDs, etc.  To run the
+[GetOffer.java](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/rpccalls/GetOffer.java)
+example, your will need to change the hard-coded offer ID to a real offer ID to avoid a "not found" 
+exception.
+
+## Java API Bots
+
+### Purpose
+
+The Java API bots in this project are meant run on mainnet, provide a base for more complex bots, and guide you in 
+developing your own bots.
+
+### Run on mainnet at your own risk!
+
+You need to understand a bot's code and its configuration before trying it on mainnet.  While you get familiar with
+a bot example, you can run it in **dryrun** mode to see how it behaves with different configurations (more later).
+Even better:  run it while your Bisq API daemons (seednode, arbitration-node, and a trading peer) are connected to a 
+local BTC regtest network.
+The [API test harness](https://github.com/bisq-network/bisq/blob/master/apitest/docs/api-beta-test-guide.md) is
+convenient for this.  
+
+#### Quick And Dirty Test Harness 
+
+TODO:  Create issue for out of date https://bisq.wiki/Downloading_and_installing#Build_from_source?
+
+If you are already familiar with [building Bisq source code](https://github.com/bisq-network/bisq/blob/master/docs/build.md), 
+and have [bitcoin-core binaries](https://github.com/bitcoin/bitcoin) on your system's $PATH, you might skip the 
+[API test harness setup guide](https://github.com/bisq-network/bisq/blob/master/apitest/docs/api-beta-test-guide.md).
+
+Before you try the test harness, make sure your host is not running any bitcoind or Bisq nodes.
+
+Clone the Bisq master branch to your host, build and start it:
+```asciidoc
+#Clone Bisq source repo.
+$ git clone https://github.com/bisq-network/bisq.git [some folder]
+$ cd [some folder]
+
+#Build Bisq source, install DAO/Regtest wallet files.
+$ ./gradlew clean build :apitest:installDaoSetup -x test
+
+#Start local bitcoind (regtest) node and headless test harness nodes. 
+$ ./bisq-apitest --apiPassword=xyz --supportingApps=bitcoind,seednode,arbdaemon,alicedaemon,bobdaemon  	--shutdownAfterTests=false
+```
+To shut down the test harness, enter **^C**.
+
+#### Creating And Using Runnable Bot Jars
+
+TODO (more later)
+
+### Take BSQ / BTC / XMR / Offer Bots
+
+There are four bots for taking offers:
+
+* [TakeBestPricedOfferToBuyBsq (From You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
+* [TakeBestPricedOfferToSellBsq (To You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
+
+* [TakeBestPricedOfferToBuyBtc (From You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java)
+* [TakeBestPricedOfferToSellBtc (To You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
+
+* [TakeBestPricedOfferToBuyXmr (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
+* [TakeBestPricedOfferToSellXmr (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
+
+
+The **Take Buy/Sell BTC** bots take 1 or more offers for a given criteria as defined in each bot's configuration file
+(more later).  After the configured maximum number of offers have been taken, the bot shuts down the API daemon and 
+itself because trade payments are made outside Bisq.  The Bisq API *cannot automate the fiat or XMR trade payment and
+receipt confirmation steps of the protocol*.  When an offer is taken by the API, the trade payment steps of the protocol
+must be performed in the UI.
+
+The **Take Buy/Sell BSQ** bots take 1 or more offers for a given criteria as defined in each bot's configuration file 
+(more later).  After the configured maximum number of offers have been taken, the bot shuts down itself, but not the
+API daemon.  BSQ Swaps can be fully automated by the API because the swap transaction is completed within seconds of 
+taking a BSQ Swap offer.
+
+#### [TakeBestPricedOfferToSellBtc (To You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
+
+**Purpose**
+
+This bot waits for attractively priced SELL BTC offers to appear, takes the offers, then shuts down both the API daemon 
+and itself (the bot).  The user should then proceed to start the desktop UI application and complete the new trades.
+
+The benefit this bot provides is freeing up the user time spent watching the offer book in the UI, waiting for the
+right offer to take.  Low-priced BTC offers are taken relatively quickly;  this bot increases the chance of beating
+the other nodes at taking the offer.
+
+The disadvantage is that if the user takes offers with the API, she must complete the trades with the desktop UI.
+This problem is due to the inability of the API to fully automate every step of the trading protocol.  Sending fiat or
+XMR payments, and confirming their receipt, are manual activities performed outside the Bisq daemon and desktop UI.
+Also, the API and the desktop UI cannot run at the same time.  Care must be taken to shut down one before starting
+the other.
+
+The criteria for determining which offers to take are defined in the bot's configuration file 
+TakeBestPricedOfferToSellBtc.properties (located in project's src/main/resources directory).  The individual
+configurations are commented in the existing TakeBestPricedOfferToSellBtc.properties, which should be used as a
+template for your own use case.
+
+**Use Cases**
+
+One possible use case for this bot is to buy BTC with GBP, e.g., take a "Faster Payment" offer to sell BTC (to you) for 
+GBP at or below the current market GBP price if:
+* the offer maker is a preferred trading peer
+* the offer's BTC amount is between 0.10 and 0.25 BTC
+* the current transaction mining fee rate is less than or equal 20 sats / byte
+
+**Class Doc Link**
+
+**Configuration**
+
+* Param 1
+* Param 2
+* Param 3
+* ...
+
+**Usage**
+
+```asciidoc
+$ java -jar x.jar --password=xyz --conf=[path.conf] --dryrun=true
+```
+
+## Gradle Build File
+
+This project's [Gradle build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle),
+shows how to generate the necessary protobuf classes from the Bisq .proto files.
+
+

--- a/java-examples/README.md
+++ b/java-examples/README.md
@@ -13,7 +13,7 @@ This subproject contains:
 * A [Gradle build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle)
   that could be used as a template for your own Java API bot project.
 
-## Risks, Warnings and Flaws
+## [Risks, Warnings and Flaws](#risks-warnings-and-flaws)
 
 ### Never Run API Daemon and [Bisq GUI](https://bisq.network) On Same Host At Same Time
 
@@ -43,7 +43,7 @@ experienced Java coders (and be easily portable to other [gRPC supported languag
 For non-developers, splitting up a one-size-fits-all TakeBestPricedOffer also makes them easier to configure for various
 BTC/Fiat, XMR/BTC, and BSQ/BTC market use cases.
 
-## Generating Protobuf Code
+## [Generating Protobuf Code](#generating-protobuf-code)
 
 ### Download IDL (.proto) Files From The [Bisq Repo](https://github.com/bisq-network/bisq)
 
@@ -71,7 +71,7 @@ In a terminal:
 $ cd java-examples $ ./gradlew clean build
 ```
 
-## Java API Method Examples
+## [Java API Method Examples](#java-api-method-examples)
 
 Each class in
 the [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/rpccalls)
@@ -88,19 +88,17 @@ examples know nothing about real Payment Account IDs, Offer IDs, etc. To run the
 example, your will need to change the hard-coded offer ID to a real offer ID to avoid a "not found" gRPC 
 StatusRuntimeException from the API daemon.
 
-## Java API Bots
+## [Java API Bots](#java-api-bots)
 
 ### Purpose
 
 The Java API bots in this project are meant to be run on mainnet, provide a base for more complex bots, and guide you
 in developing your own bots.
 
-### Run on mainnet at your own risk!
-
-You need to understand a bot's code and its configuration before trying it on mainnet. While you get familiar with a bot
-example, you can run it in **dryrun** mode to see how it behaves with different configurations (more later). Even
-better:  run it while your Bisq API daemons (seednode, arbitration-node, and a trading peer) are connected to a local
-BTC regtest network.
+Put some effort into understanding a bot's code and its configuration before trying it on mainnet. While you get 
+familiar with a bot example, you can run it in **dryrun** mode to see how it behaves with different configurations 
+(more later). Even better:  run it while your Bisq API daemons (seednode, arbitration-node, and a trading peer) are 
+connected to a local BTC regtest network. 
 The [API test harness](https://github.com/bisq-network/bisq/blob/master/apitest/docs/api-beta-test-guide.md) is
 convenient for this.
 
@@ -116,26 +114,22 @@ Before you try the test harness, make sure your host is not running any bitcoind
 Clone the Bisq master branch to your host, build and start it:
 
 ```asciidoc
-#Clone Bisq source repo.
+# Clone Bisq source repo.
 $ git clone https://github.com/bisq-network/bisq.git [some folder]
 $ cd [some folder]
 
-#Build Bisq source, install DAO/Regtest wallet files.
+# Build Bisq source, install DAO/Regtest wallet files (with coins).
 $ ./gradlew clean build :apitest:installDaoSetup -x test
 
-#Start local bitcoind (regtest) node and headless test harness nodes.
+# Start local bitcoind (regtest) node and headless test harness nodes.
 $ ./bisq-apitest --apiPassword=xyz --supportingApps=bitcoind,seednode,arbdaemon,alicedaemon,bobdaemon --shutdownAfterTests=false
 ```
 
 To shut down the test harness, enter **^C**.
 
-#### Creating And Using Runnable Bot Jars
-
-TODO (more later)
-
 ### Take BSQ / BTC / XMR / Offer Bots
 
-There are four bots for taking offers:
+There are six bots for taking offers:
 
 * [TakeBestPricedOfferToBuyBsq (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
 * [TakeBestPricedOfferToSellBsq (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
@@ -146,11 +140,23 @@ There are four bots for taking offers:
 * [TakeBestPricedOfferToBuyXmr (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
 * [TakeBestPricedOfferToSellXmr (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
 
-The **Take Buy/Sell BTC** bots take 1 or more offers for a given criteria as defined in each bot's configuration file
-(more later). After the configured maximum number of offers have been taken, the bot shuts down the API daemon and
-itself because trade payments are made outside Bisq. The Bisq API *cannot automate the fiat or XMR trade payment and
-receipt confirmation steps of the protocol*. When an offer is taken by the API, the trade payment steps of the protocol
-must be performed in the UI.
+The **Take Buy/Sell BTC and XMR Offer** bots take 1 or more offers for a given criteria as defined in each bot's 
+configuration file (more later). After the configured maximum number of offers have been taken, the bot shuts down 
+the API daemon and itself because trade payments are made outside Bisq.  Bisq nodes (UI or API) do not communicate
+with your banks and XMR wallets, and *cannot automate fiat and XMR trade payments and deposit confirmations*.
+
+The Bisq trade payment protocol steps of the Bisq protocol can be performed in the UI, or you can finish the trade with 
+an API daemon and manual CLI commands:
+```asciidoc
+# If you are a BTC buyer, notify peer you have initiated fiat or XMR payment.
+$ ./bisq-cli --password=xyz --port=9998 confirmpaymentstarted --trade-id=<trade-id>
+
+# If you are a BTC seller, notify peer your have received fiat or XMR payment.
+$ ./bisq-cli --password=xyz --port=9998 confirmpaymentreceived --trade-id=<trade-d>
+
+# Close your completed trade (move it to your trade history).  
+$ ./bisq-cli --password=xyz --port=9998 closetrade --trade-id=<trade-id>
+```
 
 The **Take Buy/Sell BSQ** bots take 1 or more offers for a given criteria as defined in each bot's configuration file
 (more later). After the configured maximum number of offers have been taken, the bot shuts down itself, but not the API
@@ -170,8 +176,8 @@ nodes at taking the offer.
 
 The disadvantage is that if the user takes offers with the API, she must complete the trades with the desktop UI. This
 problem is due to the inability of the API to fully automate every step of the trading protocol. Sending fiat or XMR
-payments, and confirming their receipt, are manual activities performed outside the Bisq daemon and desktop UI. Also,
-the API and the desktop UI cannot run at the same time. Care must be taken to shut down one before starting the other.
+payments, and confirming their receipt, are manual activities performed outside the Bisq daemon and desktop UI.  When you
+switch back and forth between the API daemon and UI, be careful not to let them run at the same time.
 
 The criteria for determining which offers to take are defined in the bot's configuration file
 TakeBestPricedOfferToSellBtc.properties (located in project's src/main/resources directory). The individual
@@ -187,7 +193,7 @@ GBP at or below the current market GBP price if:
 * the offer's BTC amount is between 0.10 and 0.25 BTC
 * the current transaction mining fee rate is less than or equal 20 sats / byte
 
-**Class Doc Link**
+**Usage**
 
 **Configuration**
 
@@ -196,13 +202,56 @@ GBP at or below the current market GBP price if:
 * Param 3
 * ...
 
-**Usage**
+**Creating And Using Runnable TakeBestPricedOfferToSellBtc Jar**
 
+To create the runnable jar, see [Creating Runnable Jars](#creating-runnable-jars).
+
+To run the jar, edit the conf file for your use case, and run it:
 ```asciidoc
-$ java -jar x.jar --password=xyz --conf=[path.conf] --dryrun=true
+$ java -jar take-best-priced-offer-to-buy-btc.jar \
+    --password=xyz \
+    --dryrun=false \
+    --conf=take-best-priced-offer-to-buy-btc.conf 
 ```
 
-## Gradle Build File
+### [Creating Runnable Jars](#creating-runnable-jars)
+
+You can create runnable jars for these bots and run them in a terminal.  After building the java-examples project, run
+the script **java-examples/scripts/create-bot-jars.sh**.  You can run the jar from the
+**java-examples/scripts/java-examples** folder created by the script, or copy that folder where you like and run it
+from there.
+
+Here are the steps to create runnable bot jars.
+```asciidoc
+# Build the java-examples project.
+$ cd java-examples
+$ ./gradlew clean build
+
+# Build the runnable bot jars.  Each jar contains one class, with its dependencies defined in its MANIFEST.MF.
+$ scripts/create-bot-jars.sh
+```
+
+Each jar has its own conf file, generated from the bot source code's properties file.  For example,
+
+* take-best-priced-offer-to-buy-btc.jar 
+* take-best-priced-offer-to-buy-btc.conf
+
+are created from
+* TakeBestPricedOfferToBuyBtc.java 
+* TakeBestPricedOfferToBuyBtc.properties
+
+To run it, edit the conf file for your use case and run a java -jar command:
+
+```asciidoc
+$ java -jar take-best-priced-offer-to-buy-btc.jar \
+    --password=xyz \
+    --dryrun=false \
+    --conf=take-best-priced-offer-to-buy-btc.conf 
+```
+
+You can rename a conf file as you like, and save several copies for specific use cases.
+
+## [Gradle Build File](#gradle-build-file)
 
 This
 project's [Gradle build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle),

--- a/java-examples/README.md
+++ b/java-examples/README.md
@@ -1,117 +1,120 @@
 # Bisq API Java Examples And Bots
 
 This subproject contains:
+
 * [Java API rpc examples](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/rpccalls)
   demonstrating how to send API gRPC requests, and handle responses.
 
 * [Java API bots](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/bots)
-  to use as is on mainnet, and demonstrate how to write new API bots.  If interested in porting any bot code to
-  other languages supported by [gRPC](https://grpc.io/docs/languages), please use these Java bot examples, not the
-  Python examples.  The Python examples were written by a Python noob, and don't handle errors.
-
-  TODO Add warning about this to Python Examples README.
+  to use as is on mainnet, and demonstrate how to write new API bots. If interested in porting any bot code to other
+  languages supported by [gRPC](https://grpc.io/docs/languages), please use these Java bot examples, not the Python
+  examples. The Python examples were written by a Python noob, and don't handle errors.
 
 * A [Gradle build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle)
-  that could be used as a template for your own API bot project.
+  that could be used as a template for your own Java API bot project.
 
-## Risks And Warnings
+## Risks, Warnings and Flaws
 
 ### Never Run API Daemon and [Bisq GUI](https://bisq.network) On Same Host At Same Time
 
-The API daemon and the GUI share the same default wallet and connection ports. Beyond inevitable failures due to 
-fighting over the wallet and ports, doing so will probably corrupt your wallet. Before starting the API daemon, 
-make sure your GUI is shut down, and vice-versa. Please back up your mainnet wallet early and often with the GUI.  
-
-TODO Add warning about this to Python Examples README, Api Reference, and Beta Test Guide.
+The API daemon and the GUI share the same default wallet and connection ports. Beyond inevitable failures due to
+fighting over the wallet and ports, doing so will probably corrupt your wallet. Before starting the API daemon, make
+sure your GUI is shut down, and vice-versa. Please back up your mainnet wallet early and often with the GUI.
 
 ### Go Slow (But Much Faster Than You Click Buttons In The GUI)
 
-[Bisq](https://bisq.network) was designed to respond to manual clicks in the user interface.  It is not a 
-high-throughput, high-performance system supporting atomic transactions.  Care must be taken to avoid 
-problems due to slow wallet updates on your disk, and Tor network latency.  The API daemon enforces limits on request
-frequency via call rate metering, but you cannot assume bots can perform tasks as rapidly as the API daemon's call 
-rate meters allow.
+[Bisq](https://bisq.network) was designed to respond to manual clicks in the user interface. It is not a
+high-throughput, high-performance system supporting atomic transactions. Care must be taken to avoid problems due to
+slow wallet updates on your disk, and Tor network latency. The API daemon enforces limits on request frequency via call
+rate metering, but you cannot assume bots can perform tasks as rapidly as the API daemon's call rate meters allow.
 
 ### Run Bots On Mainnet At Your Own Risk
 
-This document would not state "these bots can be run on mainnet, as is" without reasonable confidence on the part of 
-the code's author, but if you do, you do so at your own risk.  Copious details about running them on a local BTC 
-regtest network, running on mainnet in **dryrun** mode, and each bot's configuration is provided in this document.
-Please put some effort into understanding a bot's code and its configuration before trying it on mainnet.
+This document would not state "these bots can be run on mainnet, as is" without reasonable confidence on the part of the
+code's author, but if you do, you do so at your own risk. Copious details about running them on a local BTC regtest
+network, running on mainnet in **dryrun** mode, and each bot's configuration is provided in this document. Please put
+some effort into understanding a bot's code and its configuration before trying it on mainnet.
 
-TODO Add warning about this to Python Examples README.
+### Why There Is Duplicated Code In The Bots
+
+The TakeBestPricedOffer* bots could be combined into a single class, and use multithreaded task scheduling instead of
+loops with Thread sleep instructions, but we want them to be easily understood by people who are not necessarily
+experienced Java coders (and be easily portable to other [gRPC supported language bindings](https://grpc.io/docs/languages)).
+For non-developers, splitting up a one-size-fits-all TakeBestPricedOffer also makes them easier to configure for various
+BTC/Fiat, XMR/BTC, and BSQ/BTC market use cases.
 
 ## Generating Protobuf Code
 
 ### Download IDL (.proto) Files From The [Bisq Repo](https://github.com/bisq-network/bisq)
 
-The protobuf IDL files are not part of this project, and must be downloaded from the 
-[Bisq repo](https://github.com/bisq-network/bisq/tree/master/proto/src/main/proto).
+The protobuf IDL files are not part of this project, and must be downloaded from the Bisq repository's 
+[protobuf file directory](https://github.com/bisq-network/bisq/tree/master/proto/src/main/proto).
 
-You can download them by running 
+TODO @ripcurlx, please review https://github.com/ghubstan/bisq-api-reference/pull/11
+
+You can download them by running
 [this script](https://github.com/bisq-network/bisq-api-reference/blob/main/proto-downloader/download-bisq-protos.sh)
 from your IDE or a shell:
+
 ```asciidoc
 $ proto-downloader/download-bisq-protos.sh
 ```
 
-The java-examples [build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle) 
+The java-examples [build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle)
 will generate the code from the downloaded IDL (.proto) files.
 
 You should be able to generate the protobuf Java sources and all Java examples in your IDE.
 
 In a terminal:
+
 ```asciidoc
-$ cd java-examples
-$ ./gradlew clean build
+$ cd java-examples $ ./gradlew clean build
 ```
 
 ## Java API Method Examples
 
-Each class in 
+Each class in
 the [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/java-examples/src/main/java/bisq/rpccalls)
 package is named for the RPC method call being demonstrated.
 
-Their purpose is to show how to construct a gRPC service method request with parameters, send the
-request, and print a response object if there is one.  As a rule, the request was successful if 
-no gRPC StatusRuntimeException was received from the API daemon.
+Their purpose is to show how to construct a gRPC service method request with parameters, send the request, and print a
+response object if there is one. As a rule, the request is successful if a gRPC StatusRuntimeException is not thrown
+by the API daemon.
 
-Their usage is simple;  there are no program arguments for any of them.  Just run them with an IDE
-program launcher or your shell.
-
-However, you will often need to edit the Java class and re-compile it before running it because these
-examples know nothing about real Payment Account IDs, Offer IDs, etc.  To run the
+Their usage is simple; there are no program arguments for any of them. Just run them with an IDE program launcher or
+your shell.  However, you will usually need to edit the Java class and re-compile it before running it because these 
+examples know nothing about real Payment Account IDs, Offer IDs, etc. To run the
 [GetOffer.java](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/rpccalls/GetOffer.java)
-example, your will need to change the hard-coded offer ID to a real offer ID to avoid a "not found" 
-exception.
+example, your will need to change the hard-coded offer ID to a real offer ID to avoid a "not found" gRPC 
+StatusRuntimeException from the API daemon.
 
 ## Java API Bots
 
 ### Purpose
 
-The Java API bots in this project are meant run on mainnet, provide a base for more complex bots, and guide you in 
-developing your own bots.
+The Java API bots in this project are meant to be run on mainnet, provide a base for more complex bots, and guide you
+in developing your own bots.
 
 ### Run on mainnet at your own risk!
 
-You need to understand a bot's code and its configuration before trying it on mainnet.  While you get familiar with
-a bot example, you can run it in **dryrun** mode to see how it behaves with different configurations (more later).
-Even better:  run it while your Bisq API daemons (seednode, arbitration-node, and a trading peer) are connected to a 
-local BTC regtest network.
+You need to understand a bot's code and its configuration before trying it on mainnet. While you get familiar with a bot
+example, you can run it in **dryrun** mode to see how it behaves with different configurations (more later). Even
+better:  run it while your Bisq API daemons (seednode, arbitration-node, and a trading peer) are connected to a local
+BTC regtest network.
 The [API test harness](https://github.com/bisq-network/bisq/blob/master/apitest/docs/api-beta-test-guide.md) is
-convenient for this.  
+convenient for this.
 
-#### Quick And Dirty Test Harness 
+#### Quick And Dirty Test Harness
 
-TODO:  Create issue for out of date https://bisq.wiki/Downloading_and_installing#Build_from_source?
-
-If you are already familiar with [building Bisq source code](https://github.com/bisq-network/bisq/blob/master/docs/build.md), 
-and have [bitcoin-core binaries](https://github.com/bitcoin/bitcoin) on your system's $PATH, you might skip the 
+If you are already familiar
+with [building Bisq source code](https://github.com/bisq-network/bisq/blob/master/docs/build.md), and
+have [bitcoin-core binaries](https://github.com/bitcoin/bitcoin) on your system's $PATH, you might skip the
 [API test harness setup guide](https://github.com/bisq-network/bisq/blob/master/apitest/docs/api-beta-test-guide.md).
 
 Before you try the test harness, make sure your host is not running any bitcoind or Bisq nodes.
 
 Clone the Bisq master branch to your host, build and start it:
+
 ```asciidoc
 #Clone Bisq source repo.
 $ git clone https://github.com/bisq-network/bisq.git [some folder]
@@ -120,9 +123,10 @@ $ cd [some folder]
 #Build Bisq source, install DAO/Regtest wallet files.
 $ ./gradlew clean build :apitest:installDaoSetup -x test
 
-#Start local bitcoind (regtest) node and headless test harness nodes. 
-$ ./bisq-apitest --apiPassword=xyz --supportingApps=bitcoind,seednode,arbdaemon,alicedaemon,bobdaemon  	--shutdownAfterTests=false
+#Start local bitcoind (regtest) node and headless test harness nodes.
+$ ./bisq-apitest --apiPassword=xyz --supportingApps=bitcoind,seednode,arbdaemon,alicedaemon,bobdaemon --shutdownAfterTests=false
 ```
+
 To shut down the test harness, enter **^C**.
 
 #### Creating And Using Runnable Bot Jars
@@ -133,53 +137,52 @@ TODO (more later)
 
 There are four bots for taking offers:
 
-* [TakeBestPricedOfferToBuyBsq (From You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
-* [TakeBestPricedOfferToSellBsq (To You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
+* [TakeBestPricedOfferToBuyBsq (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
+* [TakeBestPricedOfferToSellBsq (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
 
-* [TakeBestPricedOfferToBuyBtc (From You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java)
-* [TakeBestPricedOfferToSellBtc (To You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
+* [TakeBestPricedOfferToBuyBtc (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java)
+* [TakeBestPricedOfferToSellBtc (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
 
 * [TakeBestPricedOfferToBuyXmr (From You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
 * [TakeBestPricedOfferToSellXmr (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
 
-
 The **Take Buy/Sell BTC** bots take 1 or more offers for a given criteria as defined in each bot's configuration file
-(more later).  After the configured maximum number of offers have been taken, the bot shuts down the API daemon and 
-itself because trade payments are made outside Bisq.  The Bisq API *cannot automate the fiat or XMR trade payment and
-receipt confirmation steps of the protocol*.  When an offer is taken by the API, the trade payment steps of the protocol
+(more later). After the configured maximum number of offers have been taken, the bot shuts down the API daemon and
+itself because trade payments are made outside Bisq. The Bisq API *cannot automate the fiat or XMR trade payment and
+receipt confirmation steps of the protocol*. When an offer is taken by the API, the trade payment steps of the protocol
 must be performed in the UI.
 
-The **Take Buy/Sell BSQ** bots take 1 or more offers for a given criteria as defined in each bot's configuration file 
-(more later).  After the configured maximum number of offers have been taken, the bot shuts down itself, but not the
-API daemon.  BSQ Swaps can be fully automated by the API because the swap transaction is completed within seconds of 
-taking a BSQ Swap offer.
+The **Take Buy/Sell BSQ** bots take 1 or more offers for a given criteria as defined in each bot's configuration file
+(more later). After the configured maximum number of offers have been taken, the bot shuts down itself, but not the API
+daemon. BSQ Swaps can be fully automated by the API because the swap transaction is completed within seconds of taking a
+BSQ Swap offer.
 
-#### [TakeBestPricedOfferToSellBtc (To You)](https://github.com/bisq-network/bisq-api-reference/blob/update-java-examples-readme/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
+#### [TakeBestPricedOfferToSellBtc (To You)](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
 
 **Purpose**
 
-This bot waits for attractively priced SELL BTC offers to appear, takes the offers, then shuts down both the API daemon 
-and itself (the bot).  The user should then proceed to start the desktop UI application and complete the new trades.
+This bot waits for attractively priced SELL BTC offers to appear, takes the offers, then shuts down both the API daemon
+and itself (the bot). The user should then proceed to start the desktop UI application and complete the new trades.
 
-The benefit this bot provides is freeing up the user time spent watching the offer book in the UI, waiting for the
-right offer to take.  Low-priced BTC offers are taken relatively quickly;  this bot increases the chance of beating
-the other nodes at taking the offer.
+The benefit this bot provides is freeing up the user time spent watching the offer book in the UI, waiting for the right
+offer to take. Low-priced BTC offers are taken relatively quickly; this bot increases the chance of beating the other
+nodes at taking the offer.
 
-The disadvantage is that if the user takes offers with the API, she must complete the trades with the desktop UI.
-This problem is due to the inability of the API to fully automate every step of the trading protocol.  Sending fiat or
-XMR payments, and confirming their receipt, are manual activities performed outside the Bisq daemon and desktop UI.
-Also, the API and the desktop UI cannot run at the same time.  Care must be taken to shut down one before starting
-the other.
+The disadvantage is that if the user takes offers with the API, she must complete the trades with the desktop UI. This
+problem is due to the inability of the API to fully automate every step of the trading protocol. Sending fiat or XMR
+payments, and confirming their receipt, are manual activities performed outside the Bisq daemon and desktop UI. Also,
+the API and the desktop UI cannot run at the same time. Care must be taken to shut down one before starting the other.
 
-The criteria for determining which offers to take are defined in the bot's configuration file 
-TakeBestPricedOfferToSellBtc.properties (located in project's src/main/resources directory).  The individual
-configurations are commented in the existing TakeBestPricedOfferToSellBtc.properties, which should be used as a
-template for your own use case.
+The criteria for determining which offers to take are defined in the bot's configuration file
+TakeBestPricedOfferToSellBtc.properties (located in project's src/main/resources directory). The individual
+configurations are commented in the existing TakeBestPricedOfferToSellBtc.properties, which should be used as a template
+for your own use case.
 
 **Use Cases**
 
-One possible use case for this bot is to buy BTC with GBP, e.g., take a "Faster Payment" offer to sell BTC (to you) for 
+One possible use case for this bot is to buy BTC with GBP, e.g., take a "Faster Payment" offer to sell BTC (to you) for
 GBP at or below the current market GBP price if:
+
 * the offer maker is a preferred trading peer
 * the offer's BTC amount is between 0.10 and 0.25 BTC
 * the current transaction mining fee rate is less than or equal 20 sats / byte
@@ -201,7 +204,8 @@ $ java -jar x.jar --password=xyz --conf=[path.conf] --dryrun=true
 
 ## Gradle Build File
 
-This project's [Gradle build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle),
+This
+project's [Gradle build file](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/build.gradle),
 shows how to generate the necessary protobuf classes from the Bisq .proto files.
 
 

--- a/java-examples/README.md
+++ b/java-examples/README.md
@@ -135,7 +135,6 @@ There are six bots for taking offers:
 * [Take Best Priced Offer To Buy Btc](#take-best-priced-offer-to-buy-btc)
 * [Take Best Priced Offer To Sell Btc](#take-best-priced-offer-to-sell-btc)
 
-
 * [Take Best Priced Offer To Buy Bsq](#take-best-priced-offer-to-buy-bsq)
 * [Take Best Priced Offer To Sell Bsq](#take-best-priced-offer-to-sell-bsq)
 
@@ -189,16 +188,16 @@ This information is found in
 the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java)
 .
 
-**Creating And Using Runnable TakeBestPricedOfferToSellBtc Jar**
+**Creating And Using Runnable TakeBestPricedOfferToBuyBtc Jar**
 
 To create a runnable jar, see [Creating Runnable Jars](#creating-runnable-jars). To run the jar, edit the conf file for
 your use case, and use the java -jar command:
 
 ```asciidoc
-$ java -jar take-best-priced-offer-to-sell-btc.jar \
+$ java -jar take-best-priced-offer-to-buy-btc.jar \
     --password=xyz \
     --dryrun=false \
-    --conf=take-best-priced-offer-to-sell-btc.conf 
+    --conf=take-best-priced-offer-to-buy-btc.conf 
 ```
 
 ### [Take Best Priced Offer To Sell Btc](#take-best-priced-offer-to-sell-btc)
@@ -231,14 +230,23 @@ To create a runnable jar, see [Creating Runnable Jars](#creating-runnable-jars).
 your use case, and use the java -jar command:
 
 ```asciidoc
-$ java -jar take-best-priced-offer-to-buy-btc.jar \
+$ java -jar take-best-priced-offer-to-sell-btc.jar \
     --password=xyz \
     --dryrun=false \
-    --conf=take-best-priced-offer-to-buy-btc.conf 
+    --conf=take-best-priced-offer-to-sell-btc.conf 
 ```
 
-
 ### [Take Best Priced Offer To Buy Bsq](#take-best-priced-offer-to-buy-bsq)
+
+**Purpose (Sell High)**
+
+This bot waits for attractively priced BUY BSQ (with BTC) offers to appear, and takes 1 or more of them according to
+the bot's configuration. The bot will consider only those offers created with the same payment method associated with
+your bot's configured payment account id.
+
+**Warning**
+
+Take special care to not run the Bisq API daemon and the desktop application at the same time on the same host.
 
 **Use Cases, Usage and Configuration**
 
@@ -246,7 +254,29 @@ This information is found in
 the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
 .
 
+**Creating And Using Runnable TakeBestPricedOfferToBuyBsq Jar**
+
+To create a runnable jar, see [Creating Runnable Jars](#creating-runnable-jars). To run the jar, edit the conf file for
+your use case, and use the java -jar command:
+
+```asciidoc
+$ java -jar take-best-priced-offer-to-buy-bsq.jar \
+    --password=xyz \
+    --dryrun=false \
+    --conf=take-best-priced-offer-to-buy-bsq.conf 
+```
+
 ### [Take Best Priced Offer To Sell Bsq](#take-best-priced-offer-to-sell-bsq)
+
+**Purpose (Buy Low)**
+
+This bot waits for attractively priced SELL BSQ (for BTC) offers to appear, and takes 1 or more of them according to
+the bot's configuration. The bot will consider only those offers created with the same payment method associated with
+your bot's configured payment account id.
+
+**Warning**
+
+Take special care to not run the Bisq API daemon and the desktop application at the same time on the same host.
 
 **Use Cases, Usage and Configuration**
 
@@ -254,7 +284,29 @@ This information is found in
 the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
 .
 
+**Creating And Using Runnable TakeBestPricedOfferToSellBsq Jar**
+
+To create a runnable jar, see [Creating Runnable Jars](#creating-runnable-jars). To run the jar, edit the conf file for
+your use case, and use the java -jar command:
+
+```asciidoc
+$ java -jar take-best-priced-offer-to-sell-bsq.jar \
+    --password=xyz \
+    --dryrun=false \
+    --conf=take-best-priced-offer-to-sell-bsq.conf 
+```
+
 ### [Take Best Priced Offer To Buy Xmr](#take-best-priced-offer-to-buy-xmr)
+
+**Purpose (Sell High)**
+
+This bot waits for attractively priced BUY XMR (with BTC) offers to appear, and takes 1 or more of them according to
+the bot's configuration. The bot will consider only those offers created with the same payment method associated with
+your bot's configured payment account id.
+
+**Warning**
+
+Take special care to not run the Bisq API daemon and the desktop application at the same time on the same host.
 
 **Use Cases, Usage and Configuration**
 
@@ -262,7 +314,29 @@ This information is found in
 the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
 .
 
+**Creating And Using Runnable TakeBestPricedOfferToBuyXmr Jar**
+
+To create a runnable jar, see [Creating Runnable Jars](#creating-runnable-jars). To run the jar, edit the conf file for
+your use case, and use the java -jar command:
+
+```asciidoc
+$ java -jar take-best-priced-offer-to-buy-xmr.jar \
+    --password=xyz \
+    --dryrun=false \
+    --conf=take-best-priced-offer-to-buy-xmr.conf 
+```
+
 ### [Take Best Priced Offer To Sell Xmr](#take-best-priced-offer-to-sell-xmr)
+
+**Purpose (Buy Low)**
+
+This bot waits for attractively priced SELL XMR (for BTC) offers to appear, and takes 1 or more of them according to
+the bot's configuration. The bot will consider only those offers created with the same payment method associated with
+your bot's configured payment account id.
+
+**Warning**
+
+Take special care to not run the Bisq API daemon and the desktop application at the same time on the same host.
 
 **Use Cases, Usage and Configuration**
 
@@ -270,7 +344,17 @@ This information is found in
 the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
 .
 
+**Creating And Using Runnable TakeBestPricedOfferToSellXmr Jar**
 
+To create a runnable jar, see [Creating Runnable Jars](#creating-runnable-jars). To run the jar, edit the conf file for
+your use case, and use the java -jar command:
+
+```asciidoc
+$ java -jar take-best-priced-offer-to-sell-xmr.jar \
+    --password=xyz \
+    --dryrun=false \
+    --conf=take-best-priced-offer-to-sell-xmr.conf 
+```
 
 ### [Creating Runnable Jars](#creating-runnable-jars)
 

--- a/java-examples/README.md
+++ b/java-examples/README.md
@@ -185,7 +185,7 @@ Take special care to not run the Bisq API daemon and the desktop application at 
 **Use Cases, Usage and Configuration**
 
 This information is found in
-the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java)
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java)
 .
 
 **Creating And Using Runnable TakeBestPricedOfferToBuyBtc Jar**
@@ -221,7 +221,7 @@ Take special care to not run the Bisq API daemon and the desktop application at 
 **Use Cases, Usage and Configuration**
 
 This information is found in
-the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java)
 .
 
 **Creating And Using Runnable TakeBestPricedOfferToSellBtc Jar**
@@ -251,7 +251,7 @@ Take special care to not run the Bisq API daemon and the desktop application at 
 **Use Cases, Usage and Configuration**
 
 This information is found in
-the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java)
 .
 
 **Creating And Using Runnable TakeBestPricedOfferToBuyBsq Jar**
@@ -281,7 +281,7 @@ Take special care to not run the Bisq API daemon and the desktop application at 
 **Use Cases, Usage and Configuration**
 
 This information is found in
-the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java)
 .
 
 **Creating And Using Runnable TakeBestPricedOfferToSellBsq Jar**
@@ -311,7 +311,7 @@ Take special care to not run the Bisq API daemon and the desktop application at 
 **Use Cases, Usage and Configuration**
 
 This information is found in
-the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java)
 .
 
 **Creating And Using Runnable TakeBestPricedOfferToBuyXmr Jar**
@@ -341,7 +341,7 @@ Take special care to not run the Bisq API daemon and the desktop application at 
 **Use Cases, Usage and Configuration**
 
 This information is found in
-the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
+the [source code's Java class level documentation](https://github.com/bisq-network/bisq-api-reference/blob/main/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java)
 .
 
 **Creating And Using Runnable TakeBestPricedOfferToSellXmr Jar**

--- a/java-examples/scripts/create-bot-jars.sh
+++ b/java-examples/scripts/create-bot-jars.sh
@@ -45,6 +45,9 @@ extractdistribution
 ./create-runnable-jar.sh "$GRADLE_DIST_NAME" bisq.bots.TakeBestPricedOfferToBuyBtc
 ./create-runnable-jar.sh "$GRADLE_DIST_NAME" bisq.bots.TakeBestPricedOfferToSellBtc
 
+./create-runnable-jar.sh "$GRADLE_DIST_NAME" bisq.bots.TakeBestPricedOfferToBuyXmr
+./create-runnable-jar.sh "$GRADLE_DIST_NAME" bisq.bots.TakeBestPricedOfferToSellXmr
+
 ./create-runnable-jar.sh "$GRADLE_DIST_NAME" bisq.bots.TakeBestPricedOfferToBuyBsq
 ./create-runnable-jar.sh "$GRADLE_DIST_NAME" bisq.bots.TakeBestPricedOfferToSellBsq
 

--- a/java-examples/scripts/create-runnable-jar.sh
+++ b/java-examples/scripts/create-runnable-jar.sh
@@ -84,15 +84,15 @@ MAINCLASS_FILE_PATH=$(getmainclassfilepath "$FULLY_QUALIFIED_CLASSNAME")
 
 # Extract the Main-Class from the distribution jar, to the current working directory.
 jar xfv "lib/$GRADLE_DIST_NAME.jar" "$MAINCLASS_FILE_PATH" "$SIMPLE_CLASSNAME.properties"
-echo "Extracted one class:"
-ls -l bisq/bots/pazza
+echo "Extracted $SIMPLE_CLASSNAME.class:"
+ls -l "bisq/bots/$SIMPLE_CLASSNAME.class"
 mv "$SIMPLE_CLASSNAME.properties" "$JAR_BASENAME.conf"
-echo "Extracted one properties file and renamed it $JAR_BASENAME.conf"
-ls -l *.conf
+echo "Extracted $SIMPLE_CLASSNAME.properties and renamed it $JAR_BASENAME.conf"
+ls -l "$JAR_BASENAME.conf"
 
 # Now it can be added to the empty jar with the correct path.
 jar uf "$JAR_BASENAME.jar" "$MAINCLASS_FILE_PATH"
-# Remove bisq (bisq/bots/junk).
+# Remove workarea.
 rm -rf bisq
 
 echo "Runnable $JAR_BASENAME.jar is ready to use."

--- a/java-examples/src/main/java/bisq/bots/AbstractBot.java
+++ b/java-examples/src/main/java/bisq/bots/AbstractBot.java
@@ -593,11 +593,10 @@ public abstract class AbstractBot {
      */
     protected void printTradesSummaryForTodayIfWalletIsUnlocked() {
         try {
-            log.info("Here are today's completed trades:");
             printTradesSummaryForToday(CLOSED);
         } catch (StatusRuntimeException grpcException) {
             if (walletIsLocked(grpcException)) {
-                log.error("Cannot retrieve trades while API daemon's wallet is locked.");
+                log.error("Cannot show today's trades while API daemon's wallet is locked.");
             } else {
                 throw grpcException;
             }
@@ -614,7 +613,12 @@ public abstract class AbstractBot {
         var trades = getTrades(category).stream()
                 .filter(t -> t.getDate() >= midnightToday)
                 .collect(Collectors.toList());
-        BotUtils.printTradesSummary(category, trades);
+        if (trades.isEmpty()) {
+            log.info("No trades have been completed today.");
+        } else {
+            log.info("Here are today's completed trades:");
+            BotUtils.printTradesSummary(category, trades);
+        }
     }
 
     /**
@@ -805,7 +809,6 @@ public abstract class AbstractBot {
      * @param maxTakeOffers  the max number of offers that can be taken during bot run
      */
     protected void maybeShutdownAfterSuccessfulSwap(int numOffersTaken, int maxTakeOffers) {
-        log.info("Here are today's completed trades:");
         printTradesSummaryForToday(CLOSED);
 
         if (!isDryRun) {

--- a/java-examples/src/main/java/bisq/bots/AbstractBot.java
+++ b/java-examples/src/main/java/bisq/bots/AbstractBot.java
@@ -807,8 +807,8 @@ public abstract class AbstractBot {
     protected void maybeShutdownAfterSuccessfulSwap(int numOffersTaken, int maxTakeOffers) {
         printTradesSummaryForTodayIfWalletIsUnlocked();
 
-        log.info("You {} have taken {} swap offer(s) during this bot's {}",
-                isDryRun ? "would" : "",
+        log.info("You {}have taken {} swap offer(s) during this bot's {}",
+                isDryRun ? "would " : "",
                 numOffersTaken,
                 isDryRun ? "dryrun:" : "session.");
         if (isDryRun) {

--- a/java-examples/src/main/java/bisq/bots/AbstractBot.java
+++ b/java-examples/src/main/java/bisq/bots/AbstractBot.java
@@ -890,7 +890,11 @@ public abstract class AbstractBot {
         try {
             var defaultFilename = defaultPropertiesFilename.get();
             properties.load(this.getClass().getClassLoader().getResourceAsStream(defaultFilename));
-            log.info("Internal configuration loaded from {}.", defaultFilename);
+            if (this instanceof RegtestTradePaymentSimulator) {
+                log.debug("Internal configuration loaded from {}.", defaultFilename);
+            } else {
+                log.info("Internal configuration loaded from {}.", defaultFilename);
+            }
         } catch (Exception ex) {
             throw new IllegalStateException(ex);
         }
@@ -911,7 +915,11 @@ public abstract class AbstractBot {
             Properties properties = new java.util.Properties();
             try {
                 properties.load(is);
-                log.info("External configuration loaded from {}.", confFile.getAbsolutePath());
+                if (this instanceof RegtestTradePaymentSimulator) {
+                    log.debug("External configuration loaded from {}.", confFile.getAbsolutePath());
+                } else {
+                    log.info("External configuration loaded from {}.", confFile.getAbsolutePath());
+                }
                 return properties;
             } catch (FileNotFoundException ignored) {
                 // Cannot happen here.  Ignore FileNotFoundException because confFile.exists() == true.

--- a/java-examples/src/main/java/bisq/bots/AbstractBot.java
+++ b/java-examples/src/main/java/bisq/bots/AbstractBot.java
@@ -795,35 +795,30 @@ public abstract class AbstractBot {
     }
 
     /**
-     * Print the day's completed trades since midnight today, then:
+     * Print the day's completed trades since midnight today, and number of offers taken during the bot session, then,
      * <p>
-     * If numOffersTaken >= maxTakeOffers, and trade completion is being simulated on regtest, shut down the bot.
+     * If numOffersTaken >= maxTakeOffers, shut down the bot.
      * <p>
-     * If numOffersTaken >= maxTakeOffers, and mainnet trade completion must be delegated to the UI, shut down the
-     * API daemon and the bot.
-     * <p>
-     * If numOffersTaken < maxTakeOffers, just log the number of offers taken so far during the bot run.
-     * (Don't shut down anything.)
+     * If numOffersTaken < maxTakeOffers, log the number of offers taken so far during the bot run.
      *
      * @param numOffersTaken the number of offers taken during bot run
      * @param maxTakeOffers  the max number of offers that can be taken during bot run
      */
     protected void maybeShutdownAfterSuccessfulSwap(int numOffersTaken, int maxTakeOffers) {
-        printTradesSummaryForToday(CLOSED);
+        printTradesSummaryForTodayIfWalletIsUnlocked();
 
-        if (!isDryRun) {
-            try {
-                lockWallet();
-            } catch (NonFatalException ex) {
-                log.warn(ex.getMessage());
-            }
+        log.info("You {} have taken {} swap offer(s) during this bot's {}",
+                isDryRun ? "would" : "",
+                numOffersTaken,
+                isDryRun ? "dryrun:" : "session.");
+        if (isDryRun) {
+            printDryRunProgress();
         }
+
         if (numOffersTaken >= maxTakeOffers) {
             isShutdown = true;
             log.info("Shutting down API bot after executing {} BSQ swaps.", numOffersTaken);
             exit(0);
-        } else {
-            log.info("You have completed {} BSQ swap(s) during this bot session.", numOffersTaken);
         }
     }
 

--- a/java-examples/src/main/java/bisq/bots/BotUtils.java
+++ b/java-examples/src/main/java/bisq/bots/BotUtils.java
@@ -42,6 +42,7 @@ import static java.lang.String.format;
 import static java.lang.System.*;
 import static java.math.BigDecimal.ZERO;
 import static java.math.RoundingMode.HALF_UP;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Convenience methods and functions not depending on a bot's state nor the need to send requests to the API daemon.
@@ -407,6 +408,7 @@ public class BotUtils {
      * @param offer printed offer
      */
     public static void printOfferSummary(OfferInfo offer) {
+        requireNonNull(offer, "OfferInfo offer param cannot be null.");
         new TableBuilder(OFFER_TBL, offer).build().print(out);
     }
 
@@ -416,7 +418,12 @@ public class BotUtils {
      * @param offers printed offer list
      */
     public static void printOffersSummary(List<OfferInfo> offers) {
-        new TableBuilder(OFFER_TBL, offers).build().print(out);
+        requireNonNull(offers, "List<OfferInfo> offers param cannot be null.");
+        if (offers.isEmpty()) {
+            log.info("No offers to print.");
+        } else {
+            new TableBuilder(OFFER_TBL, offers).build().print(out);
+        }
     }
 
     /**
@@ -425,6 +432,7 @@ public class BotUtils {
      * @param trade printed trade
      */
     public static void printTradeSummary(TradeInfo trade) {
+        requireNonNull(trade, "TradeInfo trade param cannot be null.");
         new TableBuilder(TRADE_DETAIL_TBL, trade).build().print(out);
     }
 
@@ -435,10 +443,15 @@ public class BotUtils {
      * @param trades   list of trades
      */
     public static void printTradesSummary(GetTradesRequest.Category category, List<TradeInfo> trades) {
-        switch (category) {
-            case CLOSED -> new TableBuilder(CLOSED_TRADES_TBL, trades).build().print(out);
-            case FAILED -> new TableBuilder(FAILED_TRADES_TBL, trades).build().print(out);
-            default -> new TableBuilder(OPEN_TRADES_TBL, trades).build().print(out);
+        requireNonNull(trades, "List<TradeInfo> trades param cannot be null.");
+        if (trades.isEmpty()) {
+            log.info("No trades to print.");
+        } else {
+            switch (category) {
+                case CLOSED -> new TableBuilder(CLOSED_TRADES_TBL, trades).build().print(out);
+                case FAILED -> new TableBuilder(FAILED_TRADES_TBL, trades).build().print(out);
+                default -> new TableBuilder(OPEN_TRADES_TBL, trades).build().print(out);
+            }
         }
     }
 
@@ -448,6 +461,7 @@ public class BotUtils {
      * @param paymentAccount the printed PaymentAccount
      */
     public static void printPaymentAccountSummary(PaymentAccount paymentAccount) {
+        requireNonNull(paymentAccount, "PaymentAccount paymentAccount param cannot be null.");
         new TableBuilder(PAYMENT_ACCOUNT_TBL, paymentAccount).build().print(out);
     }
 

--- a/java-examples/src/main/java/bisq/bots/BotUtils.java
+++ b/java-examples/src/main/java/bisq/bots/BotUtils.java
@@ -552,7 +552,6 @@ public class BotUtils {
         log.warn(BANNER);
     }
 
-
     /**
      * Log a CLI gettrade command for a simulated trading peer.
      *
@@ -571,6 +570,23 @@ public class BotUtils {
                 tradingPeerApiPassword,
                 tradingPeerApiPort,
                 tradeId);
+        log.warn(BANNER);
+    }
+
+    /**
+     * Log 1 or more CLI commands for a simulated trading peer.
+     * Commands need to be separated by newlines to be legible.
+     *
+     * @param log         calling bot's logger
+     * @param description description of CLI commands
+     * @param commands    CLI commands separated by newlines.
+     */
+    public static void printCliCommands(Logger log,
+                                        String description,
+                                        String commands) {
+        log.warn(BANNER);
+        log.warn(description);
+        log.warn(commands);
         log.warn(BANNER);
     }
 

--- a/java-examples/src/main/java/bisq/bots/BotUtils.java
+++ b/java-examples/src/main/java/bisq/bots/BotUtils.java
@@ -552,6 +552,28 @@ public class BotUtils {
         log.warn(BANNER);
     }
 
+
+    /**
+     * Log a CLI gettrade command for a simulated trading peer.
+     *
+     * @param log                    calling bot's logger
+     * @param tradingPeerApiPassword trading peer's CLI --password param value
+     * @param tradingPeerApiPort     trading peer's CLI --port param value
+     * @param tradeId                trade's unique identifier (cannot be short-id)
+     */
+    public static void printCliGetTradeCommand(Logger log,
+                                               String tradingPeerApiPassword,
+                                               int tradingPeerApiPort,
+                                               String tradeId) {
+        log.warn(BANNER);
+        log.warn("Trading peer can view a trade with a gettrade CLI command:");
+        log.warn("./bisq-cli --password={} --port={} gettrade --trade-id={}",
+                tradingPeerApiPassword,
+                tradingPeerApiPort,
+                tradeId);
+        log.warn(BANNER);
+    }
+
     /**
      * Run a bash script to count down the given number of seconds, printing each character of output from stdout.
      * <p>

--- a/java-examples/src/main/java/bisq/bots/BotUtils.java
+++ b/java-examples/src/main/java/bisq/bots/BotUtils.java
@@ -153,6 +153,13 @@ public class BotUtils {
                     && new BigDecimal(offer.getPrice()).compareTo(targetPrice) >= 0;
 
     /**
+     * Return true if the margin price based offer's market price margin (%) >= minxMarketPriceMargin (%).
+     */
+    public static final BiPredicate<OfferInfo, BigDecimal> isMarginGEMinMarketPriceMargin =
+            (offer, minMarketPriceMargin) -> offer.getUseMarketBasedPrice()
+                    && offer.getMarketPriceMarginPct() >= minMarketPriceMargin.doubleValue();
+
+    /**
      * Return true if the margin price based offer's market price margin (%) <= maxMarketPriceMargin (%).
      */
     public static final BiPredicate<OfferInfo, BigDecimal> isMarginLEMaxMarketPriceMargin =
@@ -198,9 +205,15 @@ public class BotUtils {
     }
 
     /**
+     * Return String "above" if minMarketPriceMargin (%) >= 0.00, else "below".
+     */
+    public static final Function<BigDecimal, String> aboveOrBelowMinMarketPriceMargin = (minMarketPriceMargin) ->
+            minMarketPriceMargin.compareTo(ZERO) >= 0 ? "above" : "below";
+
+    /**
      * Return String "below" if maxMarketPriceMargin (%) <= 0.00, else "above".
      */
-    public static final Function<BigDecimal, String> aboveOrBelowMarketPrice = (maxMarketPriceMargin) ->
+    public static final Function<BigDecimal, String> aboveOrBelowMaxMarketPriceMargin = (maxMarketPriceMargin) ->
             maxMarketPriceMargin.compareTo(ZERO) <= 0 ? "below" : "above";
 
     /**
@@ -268,6 +281,12 @@ public class BotUtils {
         var unvalidatedWalletPassword = readWalletPassword(walletPasswordPrompt);
         return appendWalletPasswordOpt(args, unvalidatedWalletPassword);
     };
+
+    /**
+     * Return true if the '--wallet-password' option label if found in the given program args array.
+     */
+    public static final Predicate<String[]> hasWalletPasswordOpt = (args) ->
+            Arrays.stream(args).anyMatch(a -> a.contains("--wallet-password"));
 
     /**
      * Return a wallet password read from stdin.  If read from a command terminal, input will not be echoed.

--- a/java-examples/src/main/java/bisq/bots/Config.java
+++ b/java-examples/src/main/java/bisq/bots/Config.java
@@ -17,6 +17,7 @@
 package bisq.bots;
 
 
+import joptsimple.BuiltinHelpFormatter;
 import joptsimple.OptionParser;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -63,12 +64,12 @@ public class Config {
                 .withRequiredArg();
         var confOpt = parser.accepts("conf", "Bot configuration file (required)")
                 .withRequiredArg();
-        var dryRunOpt = parser.accepts("dryrun", "Pretend to take an offer (default=false)")
+        var dryRunOpt = parser.accepts("dryrun", "Pretend to take an offer")
                 .withRequiredArg()
                 .ofType(boolean.class)
                 .defaultsTo(FALSE);
         var simulateRegtestPaymentStepsOpt =
-                parser.accepts("simulate-regtest-payment", "Simulate regtest payment steps (default=false)")
+                parser.accepts("simulate-regtest-payment", "Simulate regtest payment steps")
                         .withOptionalArg()
                         .ofType(boolean.class)
                         .defaultsTo(FALSE);
@@ -126,10 +127,23 @@ public class Config {
             stream.println();
             stream.println("Usage: ScriptName [options]");
             stream.println();
+            parser.formatHelpWith(new HelpFormatter(90, 2));
             parser.printHelpOn(stream);
             stream.println();
         } catch (IOException ex) {
             ex.printStackTrace(stream);
+        }
+    }
+
+    private static class HelpFormatter extends BuiltinHelpFormatter {
+        /**
+         * Makes a formatter with a given overall row width and column separator width.
+         *
+         * @param desiredOverallWidth         how many characters wide to make the overall help display
+         * @param desiredColumnSeparatorWidth how many characters wide to make the separation between option column and
+         */
+        public HelpFormatter(int desiredOverallWidth, int desiredColumnSeparatorWidth) {
+            super(desiredOverallWidth, desiredColumnSeparatorWidth);
         }
     }
 }

--- a/java-examples/src/main/java/bisq/bots/GrpcStubs.java
+++ b/java-examples/src/main/java/bisq/bots/GrpcStubs.java
@@ -66,8 +66,6 @@ final class GrpcStubs {
                 log.debug("Shutting down bot's grpc channel.");
                 channel.shutdown().awaitTermination(1, SECONDS);
                 log.debug("Bot channel shutdown complete.");
-            } else {
-                log.warn("Bot channel already shut down!");
             }
         } catch (InterruptedException ex) {
             throw new IllegalStateException(ex);

--- a/java-examples/src/main/java/bisq/bots/GrpcStubs.java
+++ b/java-examples/src/main/java/bisq/bots/GrpcStubs.java
@@ -63,9 +63,11 @@ final class GrpcStubs {
     public void close() {
         try {
             if (!channel.isShutdown()) {
-                log.info("Shutting down bot's grpc channel.");
+                log.debug("Shutting down bot's grpc channel.");
                 channel.shutdown().awaitTermination(1, SECONDS);
-                log.info("Bot channel shutdown complete.");
+                log.debug("Bot channel shutdown complete.");
+            } else {
+                log.warn("Bot channel already shut down!");
             }
         } catch (InterruptedException ex) {
             throw new IllegalStateException(ex);

--- a/java-examples/src/main/java/bisq/bots/RegtestTradePaymentSimulator.java
+++ b/java-examples/src/main/java/bisq/bots/RegtestTradePaymentSimulator.java
@@ -105,12 +105,11 @@ public class RegtestTradePaymentSimulator extends AbstractBot {
         closeTrade(tradeId);
         log.info("You closed the trade here in the bot (mandatory, to move trades to history list).");
 
-        log.warn("##############################################################################");
-        log.warn("Bob closes trade in the CLI (mandatory, to move trades to history list):");
-        String copyPasteCliCommands = "./bisq-cli --password=xyz --port=9999 closetrade --trade-id=" + trade.getTradeId()
+        String cliCommandDescription = "Trading peer inspects and closes trade in the CLI (mandatory, to move trades to history list):";
+        String copyPasteCliCommands = "./bisq-cli --password=xyz --port=9999 gettrade --trade-id=" + trade.getTradeId()
+                + "\n" + "./bisq-cli --password=xyz --port=9999 closetrade --trade-id=" + trade.getTradeId()
                 + "\n" + "./bisq-cli --password=xyz --port=9999 gettrades --category=closed";
-        log.warn(copyPasteCliCommands);
-        log.warn("##############################################################################");
+        printCliCommands(log, cliCommandDescription, copyPasteCliCommands);
 
         log.debug("Closing {}'s gRPC channel.", this.getClass().getSimpleName());
         super.grpcStubs.close();

--- a/java-examples/src/main/java/bisq/bots/RegtestTradePaymentSimulator.java
+++ b/java-examples/src/main/java/bisq/bots/RegtestTradePaymentSimulator.java
@@ -24,7 +24,6 @@ import protobuf.PaymentAccount;
 import java.util.Properties;
 
 import static bisq.bots.BotUtils.*;
-import static bisq.proto.grpc.GetTradesRequest.Category.CLOSED;
 import static io.grpc.Status.Code.PERMISSION_DENIED;
 
 /**
@@ -113,11 +112,7 @@ public class RegtestTradePaymentSimulator extends AbstractBot {
         log.warn(copyPasteCliCommands);
         log.warn("##############################################################################");
 
-        sleep(pollingInterval);
-        log.info("Trade is completed.  Here are today's completed trades:");
-        printTradesSummaryForToday(CLOSED);
-
-        log.info("Closing {}'s gRPC channel.", this.getClass().getSimpleName());
+        log.debug("Closing {}'s gRPC channel.", this.getClass().getSimpleName());
         super.grpcStubs.close();
     }
 

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java
@@ -334,7 +334,7 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
                     iHavePreferredTradingPeers.get()
                             ? isMakerPreferredTradingPeer.test(offer) ? "YES" : "NO"
                             : "N/A");
-            var fixedPriceLabel = format("Is offer fixed-price (%s) >= bot's minimum price (%s)?",
+            var fixedPriceLabel = format("Is offer fixed-price (%s) >= bot's minimum price of (%s)?",
                     offer.getPrice() + " BTC",
                     targetPrice + " BTC");
             filterResultsByLabel.put(fixedPriceLabel, isFixedPriceGEMaxMarketPriceMargin.test(offer, avgBsqPrice));

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java
@@ -76,6 +76,8 @@ import static protobuf.OfferDirection.SELL;
  * </pre>
  * <p>
  * The '--simulate-regtest-payment=true' option is ignored by this bot.  Taking a swap triggers execution of the swap.
+ *
+ * @see <a href="https://github.com/bisq-network/bisq-api-reference/blob/make-proto-downloader-runnable-from-any-dir/java-examples/src/main/java/bisq/bots/Config.java">bisq.bots.Config.java</a>
  */
 @Slf4j
 @Getter

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBsq.java
@@ -48,7 +48,7 @@ import static protobuf.OfferDirection.SELL;
  *
  *          the offer's BTC amount is between 0.10 and 0.25 BTC
  *          the offer maker is one of two preferred trading peers
- *          the current transaction mining fee rate is below 20 sats / byte
+ *          the current transaction mining fee rate is less than or equal 20 sats / byte
  *
  *  The bot configurations for these rules are set in TakeBestPricedOfferToBuyBsq.properties as follows:
  *

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java
@@ -43,8 +43,6 @@ import static protobuf.OfferDirection.BUY;
  * the <a href="https://bisq.network">Bisq Desktop</a> application.
  * <p>
  * Here is one possible use case:
- *
- *
  * <pre>
  *      Take 3 "Faster Payment" offers to buy BTC with GBP, priced no lower than 2.00% above the current market
  *      price if:
@@ -64,7 +62,7 @@ import static protobuf.OfferDirection.BUY;
  * </pre>
  * <b>Usage</b>
  * <p><br/>
- * You must encrypt your wallet password before running this bot.  If it is not already, you can use the CLI:
+ * You must encrypt your wallet password before running this bot.  If it is not already encrypted, you can use the CLI:
  * <pre>
  *     $ ./bisq-cli --password=xyz --port=9998 setwalletpassword --wallet-password="be careful"
  * </pre>

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java
@@ -32,35 +32,56 @@ import static java.math.RoundingMode.HALF_UP;
 import static protobuf.OfferDirection.BUY;
 
 /**
- * The TakeBestPricedOfferToBuyBtc bot waits for attractively priced BUY BTC for fiat offers to appear, takes the offers
- * (up to a maximum of configured {@link #maxTakeOffers}), then shuts down both the API daemon and itself (the bot),
- * to allow the user to start the desktop UI application and complete the trades.
+ * This bot's general use case is to sell your BTC for fiat at a high BTC price.  It periodically checks the
+ * Buy BTC market, and takes a configured maximum number of offers to buy BTC from you according to criteria you
+ * define in the bot's configuration file:  <b>TakeBestPricedOfferToBuyBtc.properties</b> (located in project's
+ * src/main/resources directory).  You will need to replace the default values in the configuration file for your
+ * use cases.
+ * <p><br/>
+ * After the maximum number of offers have been taken (good to start with 1), the bot will shut down the API daemon,
+ * then itself.  You have to confirm the offer maker's fiat payment(s) outside Bisq, then complete the trade(s) in
+ * the <a href="https://bisq.network">Bisq Desktop</a> application.
  * <p>
- * The benefit this bot provides is freeing up the user time spent watching the offer book in the UI, waiting for the
- * right offer to take.  This bot increases the chance of beating the other nodes at taking the offer.
- * <p>
- * The disadvantage is that if the user takes offers with the API, she must complete the trades with the desktop UI.
- * This problem is due to the inability of the API to fully automate every step of the trading protocol.  Sending fiat
- * payments, and confirming their receipt, are manual activities performed outside the Bisq daemon and desktop UI.
- * Also, the API and the desktop UI cannot run at the same time.  Care must be taken to shut down one before starting
- * the other.
- * <p>
- * The criteria for determining which offers to take are defined in the bot's configuration file
- * TakeBestPricedOfferToBuyBtc.properties (located in project's src/main/resources directory).  The individual
- * configurations are commented in the existing TakeBestPricedOfferToBuyBtc.properties, which should be used as a
- * template for your own use case.
- * <p>
- * One possible use case for this bot is sell BTC for GBP:
- * <pre>
- *      Take a "Faster Payment (Santander)" offer to buy BTC with GBP at or above current market price if:
- *          the offer maker is a preferred trading peer,
- *          and the offer's BTC amount is between 0.10 and 0.25 BTC,
- *          and the current transaction mining fee rate is below 20 sats / byte.
+ * Here is one possible use case:
  *
- * Usage:  TakeBestPricedOfferToBuyBtc  --password=api-password --port=api-port \
- *                          [--conf=take-best-priced-offer-to-buy-btc.conf] \
- *                          [--dryrun=true|false]
- *                          [--simulate-regtest-payment=true|false]
+ *
+ * <pre>
+ *      Take 3 "Faster Payment" offers to buy BTC with GBP, priced no lower than 2.00% above the current market
+ *      price if:
+ *
+ *          the offer's BTC amount is between 0.10 and 0.25 BTC
+ *          the offer maker is one of two preferred trading peers
+ *          the current transaction mining fee rate is below 20 sats / byte
+ *
+ *  The bot configurations for these rules are set in TakeBestPricedOfferToBuyBtc.properties as follows:
+ *
+ *          maxTakeOffers=3
+ *          minMarketPriceMargin=2.00
+ *          minAmount=0.10
+ *          maxAmount=0.25
+ *          preferredTradingPeers=preferred-address-1.onion:9999,preferred-address-2.onion:9999
+ *          maxTxFeeRate=20
+ * </pre>
+ * <b>Usage</b>
+ * <p><br/>
+ * You must encrypt your wallet password before running this bot.  If it is not already, you can use the CLI:
+ * <pre>
+ *     $ ./bisq-cli --password=xyz --port=9998 setwalletpassword --wallet-password="be careful"
+ * </pre>
+ * There are some {@link bisq.bots.Config program options} common to all the Java bot examples, passed on the command
+ * line.  The only one you must provide (no default value) is your API daemon's password option:
+ * `--password <String>`.  The bot will prompt you for your wallet-password in the console.
+ * <p><br/>
+ * You can pass the '--dryrun=true' option to the program to see what offers your bot <i>would take</i> with a given
+ * configuration.  This will help you avoid taking offers by mistake.
+ * <pre>
+ *     TakeBestPricedOfferToBuyBtc  --password=api-password --port=api-port [--dryrun=true|false]
+ * </pre>
+ * If your API daemon is running on a local regtest network (with a trading peer), you can pass the
+ * '--simulate-regtest-payment=true' option to the program to simulate the full trade protocol.  The bot will print
+ * your regtest trading peer's CLI commands in the console, for you to copy/paste into another terminal.
+ * <pre>
+ *     TakeBestPricedOfferToBuyBtc  --password=api-password --port=api-port [--simulate-regtest-payment=true|false]
  * </pre>
  */
 @Slf4j
@@ -156,7 +177,6 @@ public class TakeBestPricedOfferToBuyBtc extends AbstractBot {
                         takeCriteria.printOfferAgainstCriteria(highestPricedOffer);
                     });
 
-            printDryRunProgress();
             runCountdown(log, pollingInterval);
             pingDaemon(startTime);
         }
@@ -170,16 +190,21 @@ public class TakeBestPricedOfferToBuyBtc extends AbstractBot {
     private void takeOffer(TakeCriteria takeCriteria, OfferInfo offer) {
         log.info("Will attempt to take offer '{}'.", offer.getId());
         takeCriteria.printOfferAgainstCriteria(offer);
+
+        // An encrypted wallet must be unlocked before calling takeoffer and gettrade(s).
+        // Unlock the wallet for 5 minutes.  If the wallet is already unlocked, this request
+        // will override the timeout of the previous unlock request.
+        try {
+            unlockWallet(walletPassword, 300);
+        } catch (NonFatalException nonFatalException) {
+            handleNonFatalException(nonFatalException, pollingInterval);
+        }
+
         if (isDryRun) {
             addToOffersTaken(offer);
             numOffersTaken++;
-            maybeShutdownAfterSuccessfulTradeCreation(numOffersTaken, maxTakeOffers);
         } else {
-            // An encrypted wallet must be unlocked before calling takeoffer and gettrade.
-            // Unlock the wallet for 5 minutes.  If the wallet is already unlocked,
-            // this command will override the timeout of the previous unlock command.
             try {
-                unlockWallet(walletPassword, 600);
                 printBTCBalances("BTC Balances Before Take Offer Attempt");
                 // Blocks until new trade is prepared, or times out.
                 takeV1ProtocolOffer(offer, paymentAccount, bisqTradeFeeCurrency, pollingInterval);
@@ -194,13 +219,13 @@ public class TakeBestPricedOfferToBuyBtc extends AbstractBot {
                     printBTCBalances("BTC Balances After Simulated Trade Completion");
                 }
                 numOffersTaken++;
-                maybeShutdownAfterSuccessfulTradeCreation(numOffersTaken, maxTakeOffers);
             } catch (NonFatalException nonFatalException) {
                 handleNonFatalException(nonFatalException, pollingInterval);
             } catch (StatusRuntimeException fatalException) {
                 shutdownAfterTakeOfferFailure(fatalException);
             }
         }
+        maybeShutdownAfterSuccessfulTradeCreation(numOffersTaken, maxTakeOffers);
     }
 
     /**
@@ -218,6 +243,8 @@ public class TakeBestPricedOfferToBuyBtc extends AbstractBot {
         configsByLabel.put("Bot OS:", getOSName() + " " + getOSVersion());
         var network = getNetwork();
         configsByLabel.put("BTC Network:", network);
+        configsByLabel.put("Dry Run?", isDryRun ? "YES" : "NO");
+        configsByLabel.put("Simulate Regtest Trade?", canSimulatePaymentSteps ? "YES" : "NO");
         configsByLabel.put("My Payment Account:", "");
         configsByLabel.put("\tPayment Account Id:", paymentAccount.getId());
         configsByLabel.put("\tAccount Name:", paymentAccount.getAccountName());

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java
@@ -81,6 +81,8 @@ import static protobuf.OfferDirection.BUY;
  * <pre>
  *     TakeBestPricedOfferToBuyBtc  --password=api-password --port=api-port [--simulate-regtest-payment=true|false]
  * </pre>
+ *
+ * @see <a href="https://github.com/bisq-network/bisq-api-reference/blob/make-proto-downloader-runnable-from-any-dir/java-examples/src/main/java/bisq/bots/Config.java">bisq.bots.Config.java</a>
  */
 @Slf4j
 @Getter

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyBtc.java
@@ -49,7 +49,7 @@ import static protobuf.OfferDirection.BUY;
  *
  *          the offer's BTC amount is between 0.10 and 0.25 BTC
  *          the offer maker is one of two preferred trading peers
- *          the current transaction mining fee rate is below 20 sats / byte
+ *          the current transaction mining fee rate is less than or equal 20 sats / byte
  *
  *  The bot configurations for these rules are set in TakeBestPricedOfferToBuyBtc.properties as follows:
  *

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
@@ -32,31 +32,46 @@ import static java.math.RoundingMode.HALF_UP;
 import static protobuf.OfferDirection.SELL;
 
 /**
- * Bot for selling BSQ for BTC at an attractive (higher) price.  The bot sends BSQ for BTC.
+ * The use case for the TakeBestPricedOfferToBuyXmr bot is to sell XMR for BTC at a high BTC price, e.g.:
+ * <pre>
+ *      Take an offer to buy XMR from you for BTC, at no less than #.##% above or below current market price if:
+ *          the offer maker is a preferred trading peer,
+ *          and the offer's BTC amount is between 0.50 and 1.00 BTC,
+ *          and the current transaction mining fee rate is below 15 sats / byte.
+ *
+ * Usage:  TakeBestPricedOfferToBuyXmr  --password=api-password --port=api-port \
+ *                          [--conf=take-best-priced-offer-to-buy-xmr.conf] \
+ *                          [--dryrun=true|false]
+ *                          [--simulate-regtest-payment=true|false]
+ * </pre>
+ * <p>
+ * The criteria for determining which offers to take are defined in the bot's configuration file
+ * TakeBestPricedOfferToBuyXmr.properties (located in project's src/main/resources directory).  The individual
+ * configurations are commented in the existing TakeBestPricedOfferToBuyXmr.properties, which should be used as a
+ * template for your own use case.
  */
 @Slf4j
 @Getter
-public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
+public class TakeBestPricedOfferToBuyXmr extends AbstractBot {
 
-    // Taker bot's default BSQ payment account trading currency code.
-    private static final String CURRENCY_CODE = "BSQ";
+    // Taker bot's XMR payment account trading currency code.
+    private static final String CURRENCY_CODE = "XMR";
 
-    // Config file:  resources/TakeBestPricedOfferToBuyBsq.properties.
+    // Config file:  resources/TakeBestPricedOfferToBuyXmr.properties.
     private final Properties configFile;
-    // Taker bot's default BSQ Swap payment account.
+    // Taker bot's XMR payment account (if the configured paymentAccountId is valid).
     private final PaymentAccount paymentAccount;
-    // Taker bot's minimum market price margin.  A takeable BSQ Swap offer's fixed-price must be >= minMarketPriceMargin (%).
-    // Note:  all BSQ Swap offers have a fixed-price, but the bot uses a margin (%) of the 30-day price for comparison.
+    // Taker bot's minimum market price margin.  A takeable offer's price margin (%) must be >= minMarketPriceMargin (%).
     private final BigDecimal minMarketPriceMargin;
-    // Hard coded 30-day average BSQ trade price, used for development over regtest (ignored when running on mainnet).
-    private final BigDecimal regtest30DayAvgBsqPrice;
-    // Taker bot's minimum BTC amount to trade.  A takeable offer's amount must be >= minAmount BTC.
+    // Taker bot's min BTC amount to trade.  A takeable offer's amount must be >= minAmount BTC.
     private final BigDecimal minAmount;
-    // Taker bot's maximum BTC amount to trade.  A takeable offer's amount must be <= maxAmount BTC.
+    // Taker bot's max BTC amount to trade.   A takeable offer's amount must be <= maxAmount BTC.
     private final BigDecimal maxAmount;
     // Taker bot's max acceptable transaction fee rate.
     private final long maxTxFeeRate;
-    // Maximum # of offers to take during one bot session (shut down bot after taking N swap offers).
+    // Taker bot's trading fee currency code (BSQ or BTC).
+    private final String bisqTradeFeeCurrency;
+    // Maximum # of offers to take during one bot session (shut down bot after taking N offers).
     private final int maxTakeOffers;
 
     // Offer polling frequency must be > 1000 ms between each getoffers request.
@@ -65,32 +80,34 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
     // The # of offers taken during the bot session (since startup).
     private int numOffersTaken = 0;
 
-    public TakeBestPricedOfferToBuyBsq(String[] args) {
+    public TakeBestPricedOfferToBuyXmr(String[] args) {
         super(args);
         pingDaemon(new Date().getTime()); // Shut down now if API daemon is not available.
         this.configFile = loadConfigFile();
-        this.paymentAccount = getBsqSwapPaymentAccount();
+        this.paymentAccount = getPaymentAccount(configFile.getProperty("paymentAccountId"));
         this.minMarketPriceMargin = new BigDecimal(configFile.getProperty("minMarketPriceMargin"))
                 .setScale(2, HALF_UP);
-        this.regtest30DayAvgBsqPrice = new BigDecimal(configFile.getProperty("regtest30DayAvgBsqPrice"))
-                .setScale(8, HALF_UP);
         this.minAmount = new BigDecimal(configFile.getProperty("minAmount"));
         this.maxAmount = new BigDecimal(configFile.getProperty("maxAmount"));
         this.maxTxFeeRate = Long.parseLong(configFile.getProperty("maxTxFeeRate"));
+        this.bisqTradeFeeCurrency = configFile.getProperty("bisqTradeFeeCurrency");
         this.maxTakeOffers = Integer.parseInt(configFile.getProperty("maxTakeOffers"));
         loadPreferredOnionAddresses.accept(configFile, preferredTradingPeers);
         this.pollingInterval = Long.parseLong(configFile.getProperty("pollingInterval"));
     }
 
     /**
-     * Checks for the most attractive BSQ Swap offer to take every {@link #pollingInterval} ms.
-     * Will only terminate when manually shut down, or a fatal gRPC StatusRuntimeException is thrown.
+     * Checks for the most attractive offer to take every {@link #pollingInterval} ms.  After {@link #maxTakeOffers}
+     * are taken, bot will stop the API daemon, then shut itself down, prompting the user to start the desktop UI
+     * to complete the trade.
      */
     @Override
     public void run() {
         var startTime = new Date().getTime();
         validateWalletPassword(walletPassword);
         validatePollingInterval(pollingInterval);
+        validateTradeFeeCurrencyCode(bisqTradeFeeCurrency);
+        validatePaymentAccount(paymentAccount, CURRENCY_CODE);
         printBotConfiguration();
 
         while (!isShutdown) {
@@ -99,7 +116,8 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
                 continue;
             }
 
-            // Get all available and takeable offers, sorted by price descending.
+            // Get all available and takeable sell BTC for XMR offers, sorted by price descending.
+            // The list may contain both fixed-price and market price margin based offers.
             var offers = getOffers(SELL.name(), CURRENCY_CODE).stream()
                     .filter(o -> !isAlreadyTaken.test(o))
                     .toList();
@@ -111,7 +129,7 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
             }
 
             // Define criteria for taking an offer, based on conf file.
-            TakeBestPricedOfferToBuyBsq.TakeCriteria takeCriteria = new TakeBestPricedOfferToBuyBsq.TakeCriteria();
+            TakeCriteria takeCriteria = new TakeCriteria();
             takeCriteria.printCriteriaSummary();
             takeCriteria.printOffersAgainstCriteria(offers);
 
@@ -131,46 +149,62 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
         }
     }
 
+    /**
+     * Attempt to take the available offer according to configured criteria.  If successful, will block until a new
+     * trade is fully initialized with a trade contract.  Otherwise, handles a non-fatal error and allows the bot to
+     * stay alive, or shuts down the bot upon fatal error.
+     */
     private void takeOffer(TakeCriteria takeCriteria, OfferInfo offer) {
         log.info("Will attempt to take offer '{}'.", offer.getId());
         takeCriteria.printOfferAgainstCriteria(offer);
         if (isDryRun) {
             addToOffersTaken(offer);
             numOffersTaken++;
-            maybeShutdownAfterSuccessfulSwap(numOffersTaken, maxTakeOffers);
+            maybeShutdownAfterSuccessfulTradeCreation(numOffersTaken, maxTakeOffers);
         } else {
             // An encrypted wallet must be unlocked before calling takeoffer and gettrade.
-            // Unlock the wallet for 10 minutes.  If the wallet is already unlocked,
+            // Unlock the wallet for 5 minutes.  If the wallet is already unlocked,
             // this command will override the timeout of the previous unlock command.
             try {
                 unlockWallet(walletPassword, 600);
+                printBTCBalances("BTC Balances Before Take Offer Attempt");
+                // Blocks until new trade is prepared, or times out.
+                takeV1ProtocolOffer(offer, paymentAccount, bisqTradeFeeCurrency, pollingInterval);
+                printBTCBalances("BTC Balances After Take Offer Attempt");
 
-                printBTCBalances("BTC Balances Before Swap Execution");
-                printBSQBalances("BSQ Balances Before Swap Execution");
-
-                // Blocks until swap is executed, or times out.
-                takeBsqSwapOffer(offer, pollingInterval);
-
-                printBTCBalances("BTC Balances After Swap Execution");
-                printBSQBalances("BSQ Balances After Swap Execution");
-
+                if (canSimulatePaymentSteps) {
+                    var newTrade = getTrade(offer.getId());
+                    RegtestTradePaymentSimulator tradePaymentSimulator = new RegtestTradePaymentSimulator(args,
+                            newTrade.getTradeId(),
+                            paymentAccount);
+                    tradePaymentSimulator.run();
+                    printBTCBalances("BTC Balances After Simulated Trade Completion");
+                }
                 numOffersTaken++;
-                maybeShutdownAfterSuccessfulSwap(numOffersTaken, maxTakeOffers);
+                maybeShutdownAfterSuccessfulTradeCreation(numOffersTaken, maxTakeOffers);
             } catch (NonFatalException nonFatalException) {
                 handleNonFatalException(nonFatalException, pollingInterval);
             } catch (StatusRuntimeException fatalException) {
-                handleFatalBsqSwapException(fatalException);
+                shutdownAfterTakeOfferFailure(fatalException);
             }
         }
     }
+
+    /**
+     * Return true is fixed-price offer's price >= the bot's min market price margin.  Allows bot to take a
+     * fixed-priced offer if the price is >= {@link #minMarketPriceMargin} (%) of the current market price.
+     */
+    protected final BiPredicate<OfferInfo, BigDecimal> isFixedPriceGEMinMarketPriceMargin =
+            (offer, currentMarketPrice) -> BotUtils.isFixedPriceGEMinMarketPriceMargin(
+                    offer,
+                    currentMarketPrice,
+                    this.getMinMarketPriceMargin());
 
     private void printBotConfiguration() {
         var configsByLabel = new LinkedHashMap<String, Object>();
         configsByLabel.put("Bot OS:", getOSName() + " " + getOSVersion());
         var network = getNetwork();
         configsByLabel.put("BTC Network:", network);
-        var isMainnet = network.equalsIgnoreCase("mainnet");
-        var mainnet30DayAvgBsqPrice = isMainnet ? get30DayAvgBsqPriceInBtc() : null;
         configsByLabel.put("My Payment Account:", "");
         configsByLabel.put("\tPayment Account Id:", paymentAccount.getId());
         configsByLabel.put("\tAccount Name:", paymentAccount.getAccountName());
@@ -179,11 +213,6 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
         configsByLabel.put("\tMax # of offers bot can take:", maxTakeOffers);
         configsByLabel.put("\tMax Tx Fee Rate:", maxTxFeeRate + " sats/byte");
         configsByLabel.put("\tMin Market Price Margin:", minMarketPriceMargin + "%");
-        if (isMainnet) {
-            configsByLabel.put("\tMainnet 30-Day Avg BSQ Price:", mainnet30DayAvgBsqPrice + " BTC");
-        } else {
-            configsByLabel.put("\tRegtest 30-Day Avg BSQ Price:", regtest30DayAvgBsqPrice + " BTC");
-        }
         configsByLabel.put("\tMin BTC Amount:", minAmount + " BTC");
         configsByLabel.put("\tMax BTC Amount: ", maxAmount + " BTC");
         if (iHavePreferredTradingPeers.get()) {
@@ -195,18 +224,8 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
         log.info(toTable.apply("Bot Configuration", configsByLabel));
     }
 
-    /**
-     * Return true is fixed-price offer's price >= the bot's max market price margin.  Allows bot to take a
-     * fixed-priced offer if the price is >= {@link #minMarketPriceMargin} (%) of the current market price.
-     */
-    protected final BiPredicate<OfferInfo, BigDecimal> isFixedPriceGEMaxMarketPriceMargin =
-            (offer, currentMarketPrice) -> isFixedPriceGEMinMarketPriceMargin(
-                    offer,
-                    currentMarketPrice,
-                    this.getMinMarketPriceMargin());
-
     public static void main(String[] args) {
-        TakeBestPricedOfferToBuyBsq bot = new TakeBestPricedOfferToBuyBsq(args);
+        TakeBestPricedOfferToBuyXmr bot = new TakeBestPricedOfferToBuyXmr(args);
         bot.run();
     }
 
@@ -215,20 +234,20 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
      * performs candidate offer filtering, and provides useful log statements.
      */
     private class TakeCriteria {
-        private static final String MARKET_DESCRIPTION = "Buy BSQ (Sell BTC)";
+        private static final String MARKET_DESCRIPTION = "Buy XMR (Sell BTC)";
 
-        private final BigDecimal avgBsqPrice;
+        private final BigDecimal currentMarketPrice;
         @Getter
         private final BigDecimal targetPrice;
 
         public TakeCriteria() {
-            this.avgBsqPrice = isConnectedToMainnet() ? get30DayAvgBsqPriceInBtc() : regtest30DayAvgBsqPrice;
-            this.targetPrice = calcTargetBsqPrice(minMarketPriceMargin, avgBsqPrice);
+            this.currentMarketPrice = getCurrentMarketPrice(CURRENCY_CODE);
+            this.targetPrice = calcTargetPrice(minMarketPriceMargin, currentMarketPrice, CURRENCY_CODE);
         }
 
         /**
          * Returns the highest priced offer passing the filters, or Optional.empty() if not found.
-         * Max tx fee rate filtering should have passed prior to calling this method.
+         * The max tx fee rate filtering should have passed prior to calling this method.
          *
          * @param offers to filter
          */
@@ -237,36 +256,37 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
                 return offers.stream()
                         .filter(o -> usesSamePaymentMethod.test(o, getPaymentAccount()))
                         .filter(isMakerPreferredTradingPeer)
-                        .filter(o -> isFixedPriceGEMaxMarketPriceMargin.test(o, avgBsqPrice))
+                        .filter(o -> isMarginGEMinMarketPriceMargin.test(o, minMarketPriceMargin)
+                                || isFixedPriceGEMinMarketPriceMargin.test(o, currentMarketPrice))
                         .filter(o -> isWithinBTCAmountBounds(o, getMinAmount(), getMaxAmount()))
                         .findFirst();
             else
                 return offers.stream()
                         .filter(o -> usesSamePaymentMethod.test(o, getPaymentAccount()))
-                        .filter(o -> isFixedPriceGEMaxMarketPriceMargin.test(o, avgBsqPrice))
+                        .filter(o -> isMarginGEMinMarketPriceMargin.test(o, minMarketPriceMargin)
+                                || isFixedPriceGEMinMarketPriceMargin.test(o, currentMarketPrice))
                         .filter(o -> isWithinBTCAmountBounds(o, getMinAmount(), getMaxAmount()))
                         .findFirst();
         }
 
         void printCriteriaSummary() {
             if (isZero.test(minMarketPriceMargin)) {
-                log.info("Looking for offers to {}, with a fixed-price at or higher than"
-                                + " the 30-day average BSQ trade price of {} BTC.",
+                log.info("Looking for offers to {}, priced at or higher than the current market price of {} BTC.",
                         MARKET_DESCRIPTION,
-                        avgBsqPrice);
+                        currentMarketPrice);
             } else {
-                log.info("Looking for offers to {}, with a fixed-price at or higher than"
-                                + " {}% {} the 30-day average BSQ trade price of {} BTC.",
+                log.info("Looking for offers to {}, priced at or higher than {}% {} the current market price of {} BTC.",
                         MARKET_DESCRIPTION,
                         minMarketPriceMargin.abs(), // Hide the sign, text explains target price % "above or below".
                         aboveOrBelowMinMarketPriceMargin.apply(minMarketPriceMargin),
-                        avgBsqPrice);
+                        currentMarketPrice);
             }
         }
 
         void printOffersAgainstCriteria(List<OfferInfo> offers) {
-            log.info("Currently available {} offers -- want to take BSQ swap offer with fixed-price >= {} BTC.",
+            log.info("Currently available {} offers -- want to take {} offer with price >= {} BTC.",
                     MARKET_DESCRIPTION,
+                    CURRENCY_CODE,
                     targetPrice);
             printOffersSummary(offers);
         }
@@ -275,24 +295,35 @@ public class TakeBestPricedOfferToBuyBsq extends AbstractBot {
             printOfferSummary(offer);
 
             var filterResultsByLabel = new LinkedHashMap<String, Object>();
-            filterResultsByLabel.put("30-day Avg BSQ trade price:", avgBsqPrice + " BTC");
+            filterResultsByLabel.put("Current Market Price:", currentMarketPrice + " BTC");
             filterResultsByLabel.put("Target Price (Min):", targetPrice + " BTC");
             filterResultsByLabel.put("Offer Price:", offer.getPrice() + " BTC");
             filterResultsByLabel.put("Offer maker used same payment method?",
                     usesSamePaymentMethod.test(offer, getPaymentAccount()));
-            filterResultsByLabel.put("Is offer's maker a preferred trading peer?",
+            filterResultsByLabel.put("Is offer maker a preferred trading peer?",
                     iHavePreferredTradingPeers.get()
                             ? isMakerPreferredTradingPeer.test(offer) ? "YES" : "NO"
                             : "N/A");
-            var fixedPriceLabel = format("Is offer fixed-price (%s) >= bot's minimum price (%s)?",
-                    offer.getPrice() + " BTC",
-                    targetPrice + " BTC");
-            filterResultsByLabel.put(fixedPriceLabel, isFixedPriceGEMaxMarketPriceMargin.test(offer, avgBsqPrice));
-            var btcAmountBounds = format("%s BTC - %s BTC", minAmount, maxAmount);
+
+            if (offer.getUseMarketBasedPrice()) {
+                var marginPriceLabel = format("Is offer's price margin (%s%%) >= bot's min market price margin (%s%%)?",
+                        offer.getMarketPriceMarginPct(),
+                        minMarketPriceMargin);
+                filterResultsByLabel.put(marginPriceLabel, isMarginLEMaxMarketPriceMargin.test(offer, minMarketPriceMargin));
+            } else {
+                var fixedPriceLabel = format("Is offer's fixed-price (%s) >= bot's target price (%s)?",
+                        offer.getPrice() + " BTC",
+                        targetPrice + " BTC");
+                filterResultsByLabel.put(fixedPriceLabel, isFixedPriceGEMinMarketPriceMargin.test(offer, currentMarketPrice));
+            }
+            
+            String btcAmountBounds = format("%s BTC - %s BTC", minAmount, maxAmount);
             filterResultsByLabel.put("Is offer's BTC amount within bot amount bounds (" + btcAmountBounds + ")?",
                     isWithinBTCAmountBounds(offer, getMinAmount(), getMaxAmount()));
 
-            var title = format("Fixed price BSQ swap offer %s filter results:", offer.getId());
+            var title = format("%s offer %s filter results:",
+                    offer.getUseMarketBasedPrice() ? "Margin based" : "Fixed price",
+                    offer.getId());
             log.info(toTable.apply(title, filterResultsByLabel));
         }
     }

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
@@ -80,6 +80,8 @@ import static protobuf.OfferDirection.SELL;
  * <pre>
  *     TakeBestPricedOfferToBuyXmr  --password=api-password --port=api-port [--simulate-regtest-payment=true|false]
  * </pre>
+ *
+ * @see <a href="https://github.com/bisq-network/bisq-api-reference/blob/make-proto-downloader-runnable-from-any-dir/java-examples/src/main/java/bisq/bots/Config.java">bisq.bots.Config.java</a>
  */
 @Slf4j
 @Getter

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
@@ -76,7 +76,7 @@ import static protobuf.OfferDirection.SELL;
  * </pre>
  * If your API daemon is running on a local regtest network (with a trading peer), you can pass the
  * '--simulate-regtest-payment=true' option to the program to simulate the full trade protocol.  The bot will print
- * your regtest trading peer's CLI commands will be printed on the console, for you to copy/paste into another terminal.
+ * your regtest trading peer's CLI commands in the console, for you to copy/paste into another terminal.
  * <pre>
  *     TakeBestPricedOfferToBuyXmr  --password=api-password --port=api-port [--simulate-regtest-payment=true|false]
  * </pre>
@@ -343,9 +343,9 @@ public class TakeBestPricedOfferToBuyXmr extends AbstractBot {
                             : "N/A");
 
             if (offer.getUseMarketBasedPrice()) {
-                var marginPriceLabel = format("Is offer's price margin (%s%%) >= bot's min market price margin (%s%%)?",
-                        offer.getMarketPriceMarginPct(),
-                        minMarketPriceMargin);
+                var marginPriceLabel = format("Is offer's margin based price (%s) >= bot's target price (%s)?",
+                        offer.getPrice() + " BTC",
+                        targetPrice + " BTC");
                 filterResultsByLabel.put(marginPriceLabel, isMarginGEMinMarketPriceMargin.test(offer, minMarketPriceMargin));
             } else {
                 var fixedPriceLabel = format("Is offer's fixed-price (%s) >= bot's target price (%s)?",

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
@@ -48,7 +48,7 @@ import static protobuf.OfferDirection.SELL;
  *
  *          the offer's BTC amount is between 0.50 and 1.00 BTC
  *          the offer maker is one of two preferred trading peers
- *          the current transaction mining fee rate is below 20 sats / byte
+ *          the current transaction mining fee rate is less than or equal 20 sats / byte
  *
  *  The bot configurations for these rules are set in TakeBestPricedOfferToBuyXmr.properties as follows:
  *

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToBuyXmr.java
@@ -61,7 +61,7 @@ import static protobuf.OfferDirection.SELL;
  * </pre>
  * <b>Usage</b>
  * <p><br/>
- * You must encrypt your wallet password before running this bot.  If it is not already, you can use the CLI:
+ * You must encrypt your wallet password before running this bot.  If it is not already encrypted, you can use the CLI:
  * <pre>
  *     $ ./bisq-cli --password=xyz --port=9998 setwalletpassword --wallet-password="be careful"
  * </pre>

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java
@@ -53,7 +53,7 @@ import static protobuf.OfferDirection.BUY;
  *  The bot configurations for these rules are set in TakeBestPricedOfferToSellBsq.properties as follows:
  *
  *          maxTakeOffers=5
- *          minMarketPriceMargin=-1.00
+ *          maxMarketPriceMargin=-1.00
  *          minAmount=0.10
  *          maxAmount=0.25
  *          preferredTradingPeers=preferred-address-1.onion:9999,preferred-address-2.onion:9999

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBsq.java
@@ -32,7 +32,52 @@ import static java.math.RoundingMode.HALF_UP;
 import static protobuf.OfferDirection.BUY;
 
 /**
- * Bot for buying BSQ with BTC at an attractive (lower) price.  The bot receives BSQ for BTC.
+ * This bot's general use case is to buy BSQ with BTC at a low BTC price.  It periodically checks the
+ * Sell BSQ (Buy BTC) market, and takes a configured maximum number of offers to buy BSQ from you according to criteria
+ * you define in the bot's configuration file:  <b>TakeBestPricedOfferToSellBsq.properties</b> (located in project's
+ * src/main/resources directory).  You will need to replace the default values in the configuration file for your
+ * use cases.
+ * <p><br/>
+ * After the maximum number of BSQ swap offers have been taken (good to start with 1), the bot will shut down.  The API
+ * daemon will not be shut down because swaps do not require additional payment related steps taken outside Bisq, or
+ * in the GUI.
+ * <p>
+ * Here is one possible use case:
+ * <pre>
+ *      Take 5 BSQ swap offers to sell BSQ for BTC, priced no higher than -1.00% below the 30-day average BSQ price if:
+ *
+ *          the offer's BTC amount is between 0.10 and 0.25 BTC
+ *          the offer maker is one of two preferred trading peers
+ *          the current transaction mining fee rate is less than or equal 25 sats / byte
+ *
+ *  The bot configurations for these rules are set in TakeBestPricedOfferToSellBsq.properties as follows:
+ *
+ *          maxTakeOffers=5
+ *          minMarketPriceMargin=-1.00
+ *          minAmount=0.10
+ *          maxAmount=0.25
+ *          preferredTradingPeers=preferred-address-1.onion:9999,preferred-address-2.onion:9999
+ *          maxTxFeeRate=25
+ * </pre>
+ * <b>Usage</b>
+ * <p><br/>
+ * You must encrypt your wallet password before running this bot.  If it is not already encrypted, you can use the CLI:
+ * <pre>
+ *     $ ./bisq-cli --password=xyz --port=9998 setwalletpassword --wallet-password="be careful"
+ * </pre>
+ * There are some {@link bisq.bots.Config program options} common to all the Java bot examples, passed on the command
+ * line.  The only one you must provide (no default value) is your API daemon's password option:
+ * `--password <String>`.  The bot will prompt you for your wallet-password in the console.
+ * <p><br/>
+ * You can pass the '--dryrun=true' option to the program to see what offers your bot <i>would take</i> with a given
+ * configuration.  This will help you avoid taking offers by mistake.
+ * <pre>
+ *     TakeBestPricedOfferToBuyBsq  --password=api-password --port=api-port [--dryrun=true|false]
+ * </pre>
+ * <p>
+ * The '--simulate-regtest-payment=true' option is ignored by this bot.  Taking a swap triggers execution of the swap.
+ *
+ * @see <a href="https://github.com/bisq-network/bisq-api-reference/blob/make-proto-downloader-runnable-from-any-dir/java-examples/src/main/java/bisq/bots/Config.java">bisq.bots.Config.java</a>
  */
 @Slf4j
 @Getter
@@ -99,7 +144,8 @@ public class TakeBestPricedOfferToSellBsq extends AbstractBot {
                 continue;
             }
 
-            // Get all available and takeable offers, sorted by price ascending.
+            // Get all available buy BTC with BSQ offers, sorted by price ascending.
+            // The list contains only fixed-priced offers.
             var offers = getOffers(BUY.name(), CURRENCY_CODE).stream()
                     .filter(o -> !isAlreadyTaken.test(o))
                     .toList();
@@ -125,7 +171,6 @@ public class TakeBestPricedOfferToSellBsq extends AbstractBot {
                         takeCriteria.printOfferAgainstCriteria(cheapestOffer);
                     });
 
-            printDryRunProgress();
             runCountdown(log, pollingInterval);
             pingDaemon(startTime);
         }
@@ -134,17 +179,21 @@ public class TakeBestPricedOfferToSellBsq extends AbstractBot {
     private void takeOffer(TakeCriteria takeCriteria, OfferInfo offer) {
         log.info("Will attempt to take offer '{}'.", offer.getId());
         takeCriteria.printOfferAgainstCriteria(offer);
+
+        // An encrypted wallet must be unlocked before calling takeoffer and gettrade(s).
+        // Unlock the wallet for 5 minutes.  If the wallet is already unlocked, this request
+        // will override the timeout of the previous unlock request.
+        try {
+            unlockWallet(walletPassword, 300);
+        } catch (NonFatalException nonFatalException) {
+            handleNonFatalException(nonFatalException, pollingInterval);
+        }
+
         if (isDryRun) {
             addToOffersTaken(offer);
             numOffersTaken++;
-            maybeShutdownAfterSuccessfulSwap(numOffersTaken, maxTakeOffers);
         } else {
-            // An encrypted wallet must be unlocked before calling takeoffer and gettrade.
-            // Unlock the wallet for 10 minutes.  If the wallet is already unlocked,
-            // this command will override the timeout of the previous unlock command.
             try {
-                unlockWallet(walletPassword, 600);
-
                 printBTCBalances("BTC Balances Before Swap Execution");
                 printBSQBalances("BSQ Balances Before Swap Execution");
 
@@ -155,13 +204,13 @@ public class TakeBestPricedOfferToSellBsq extends AbstractBot {
                 printBSQBalances("BSQ Balances After Swap Execution");
 
                 numOffersTaken++;
-                maybeShutdownAfterSuccessfulSwap(numOffersTaken, maxTakeOffers);
             } catch (NonFatalException nonFatalException) {
                 handleNonFatalException(nonFatalException, pollingInterval);
             } catch (StatusRuntimeException fatalException) {
                 handleFatalBsqSwapException(fatalException);
             }
         }
+        maybeShutdownAfterSuccessfulSwap(numOffersTaken, maxTakeOffers);
     }
 
     private void printBotConfiguration() {
@@ -169,6 +218,7 @@ public class TakeBestPricedOfferToSellBsq extends AbstractBot {
         configsByLabel.put("Bot OS:", getOSName() + " " + getOSVersion());
         var network = getNetwork();
         configsByLabel.put("BTC Network:", network);
+        configsByLabel.put("Dry Run?", isDryRun ? "YES" : "NO");
         var isMainnet = network.equalsIgnoreCase("mainnet");
         var mainnet30DayAvgBsqPrice = isMainnet ? get30DayAvgBsqPriceInBtc() : null;
         configsByLabel.put("My Payment Account:", "");
@@ -226,7 +276,6 @@ public class TakeBestPricedOfferToSellBsq extends AbstractBot {
             this.targetPrice = calcTargetBsqPrice(maxMarketPriceMargin, avgBsqPrice);
         }
 
-
         /**
          * Returns the lowest priced offer passing the filters, or Optional.empty() if not found.
          * Max tx fee rate filtering should have passed prior to calling this method.
@@ -277,7 +326,7 @@ public class TakeBestPricedOfferToSellBsq extends AbstractBot {
 
             var filterResultsByLabel = new LinkedHashMap<String, Object>();
             filterResultsByLabel.put("30-day Avg BSQ trade price:", avgBsqPrice + " BTC");
-            filterResultsByLabel.put("Target Price (Min):", targetPrice + " BTC");
+            filterResultsByLabel.put("Target Price (Max):", targetPrice + " BTC");
             filterResultsByLabel.put("Offer Price:", offer.getPrice() + " BTC");
             filterResultsByLabel.put("Offer maker used same payment method?",
                     usesSamePaymentMethod.test(offer, getPaymentAccount()));
@@ -285,7 +334,7 @@ public class TakeBestPricedOfferToSellBsq extends AbstractBot {
                     iHavePreferredTradingPeers.get()
                             ? isMakerPreferredTradingPeer.test(offer) ? "YES" : "NO"
                             : "N/A");
-            var fixedPriceLabel = format("Is offer's fixed-price (%s) <= bot's minimum price (%s)?",
+            var fixedPriceLabel = format("Is offer's fixed-price (%s) <= bot's maximum price of (%s)?",
                     offer.getPrice() + " BTC",
                     targetPrice + " BTC");
             filterResultsByLabel.put(fixedPriceLabel, isFixedPriceLEMaxMarketPriceMargin.test(offer, avgBsqPrice));

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java
@@ -81,6 +81,8 @@ import static protobuf.OfferDirection.SELL;
  * <pre>
  *     TakeBestPricedOfferToBuyBtc  --password=api-password --port=api-port [--simulate-regtest-payment=true|false]
  * </pre>
+ *
+ * @see <a href="https://github.com/bisq-network/bisq-api-reference/blob/make-proto-downloader-runnable-from-any-dir/java-examples/src/main/java/bisq/bots/Config.java">bisq.bots.Config.java</a>
  */
 @Slf4j
 @Getter

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellBtc.java
@@ -49,7 +49,7 @@ import static protobuf.OfferDirection.SELL;
  *
  *          the offer's BTC amount is between 0.10 and 0.25 BTC
  *          the offer maker is one of two preferred trading peers
- *          the current transaction mining fee rate is below 20 sats / byte
+ *          the current transaction mining fee rate is less than or equal 20 sats / byte
  *
  *  The bot configurations for these rules are set in TakeBestPricedOfferToSellBtc.properties as follows:
  *

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
@@ -32,10 +32,11 @@ import static java.math.RoundingMode.HALF_UP;
 import static protobuf.OfferDirection.BUY;
 
 /**
- * This bot's general use case is to buy XMR with BTC at a low BTC price.  It periodically checks the Sell XMR (Buy BTC)
- * market, and takes a configured maximum number of offers to sell you XMR according to criteria you define in the bot's
- * configuration file:  TakeBestPricedOfferToSellXmr.properties (located in project's src/main/resources directory).
- * You will need to replace the default values in the configuration file for your use cases.
+ * This bot's general use case is to buy XMR with your BTC at a low BTC price.  It periodically checks the
+ * Sell XMR (Buy BTC) market, and takes a configured maximum number of offers to sell you XMR according to criteria you
+ * define in the bot's configuration file:  <b>TakeBestPricedOfferToSellXmr.properties</b> (located in project's
+ * src/main/resources directory).  You will need to replace the default values in the configuration file for your
+ * use cases.
  * <p><br/>
  * After the maximum number of offers have been taken (good to start with 1), the bot will shut down the API daemon,
  * then itself.  You have to confirm the offer maker's XMR payment(s) outside Bisq, then complete the trade(s) in
@@ -220,8 +221,8 @@ public class TakeBestPricedOfferToSellXmr extends AbstractBot {
             } catch (StatusRuntimeException fatalException) {
                 shutdownAfterTakeOfferFailure(fatalException);
             }
-            maybeShutdownAfterSuccessfulTradeCreation(numOffersTaken, maxTakeOffers);
         }
+        maybeShutdownAfterSuccessfulTradeCreation(numOffersTaken, maxTakeOffers);
     }
 
     /**
@@ -239,6 +240,8 @@ public class TakeBestPricedOfferToSellXmr extends AbstractBot {
         configsByLabel.put("Bot OS:", getOSName() + " " + getOSVersion());
         var network = getNetwork();
         configsByLabel.put("BTC Network:", network);
+        configsByLabel.put("Dry Run?", isDryRun ? "YES" : "NO");
+        configsByLabel.put("Simulate Regtest Trade?", canSimulatePaymentSteps ? "YES" : "NO");
         configsByLabel.put("My Payment Account:", "");
         configsByLabel.put("\tPayment Account Id:", paymentAccount.getId());
         configsByLabel.put("\tAccount Name:", paymentAccount.getAccountName());

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
@@ -32,23 +32,49 @@ import static java.math.RoundingMode.HALF_UP;
 import static protobuf.OfferDirection.BUY;
 
 /**
- * The use case for the TakeBestPricedOfferToSellXmr bot is to buy XMR with BTC at a low BTC price, e.g.:
- * <pre>
- *      Take an offer to sell you XMR for BTC, at no more than #.##% above or below current market price if:
- *          the offer maker is a preferred trading peer,
- *          and the offer's BTC amount is between 0.50 and 1.00 BTC,
- *          and the current transaction mining fee rate is below 15 sats / byte.
- *
- * Usage:  TakeBestPricedOfferToSellXmr  --password=api-password --port=api-port \
- *                          [--conf=take-best-priced-offer-to-sell-xmr.conf] \
- *                          [--dryrun=true|false]
- *                          [--simulate-regtest-payment=true|false]
- * </pre>
+ * This bot's general use case is to buy XMR with BTC at a low BTC price.  It periodically checks the Sell XMR (Buy BTC)
+ * market, and takes a configured number of offers to sell you XMR according to criteria you define in the bot's
+ * configuration file TakeBestPricedOfferToSellXmr.properties (located in project's src/main/resources directory).
+ * You will need to replace the default values in the configuration file for your use cases.
+ * <p><br/>
+ * After the maximum number of offers have been taken (good to start with 1), the bot will shut down the API daemon,
+ * then the bot itself.  You have to confirm the offer maker's XMR payment(s) offline, then complete the trade(s) in
+ * the <a href="https://bisq.network">Bisq Desktop</a> application.
  * <p>
- * The criteria for determining which offers to take are defined in the bot's configuration file
- * TakeBestPricedOfferToSellXmr.properties (located in project's src/main/resources directory).  The individual
- * configurations are commented in the existing TakeBestPricedOfferToSellXmr.properties, which should be used as a
- * template for your own use case.
+ * Here is one possible use case:
+ * <pre>
+ *  Take 1 offer to sell you XMR for BTC, priced no higher than 0.00% above or below current market price if:
+ *
+ *          the offer's BTC amount is between 0.50 and 1.00 BTC
+ *          the offer maker is one of two preferred trading peers
+ *          the current transaction mining fee rate is below 15 sats / byte
+ *
+ *  The bot configurations for these rules are set in TakeBestPricedOfferToSellXmr.properties as follows:
+ *
+ *          maxTakeOffers=1
+ *          maxMarketPriceMargin=0.00
+ *          minAmount=0.50
+ *          maxAmount=1.00
+ *          preferredTradingPeers=preferred-address-1.onion:9999,preferred-address-2.onion:9999
+ *          maxTxFeeRate=15
+ * </pre>
+ * <b>Usage</b>
+ * <p><br/>
+ * There are some {@link bisq.bots.Config program options} common to all the Java bot examples, passed on the command
+ * line.  The only one required every time the bot is run is your API daemon's password option: `--password <String>`.
+ * The bot will prompt you for your wallet-password in the console.
+ * <p><br/>
+ * You can pass the '--dryrun=true' option to the program to see what offers your bot <i>would take</i> with a given
+ * configuration.  This will help you avoid taking offers by mistake.
+ * <pre>
+ *     TakeBestPricedOfferToSellXmr  --password=api-password --port=api-port [--dryrun=true|false]
+ * </pre>
+ * If your API daemon is running on a local regtest network (with a trading peer), you can pass the
+ * '--simulate-regtest-payment=true' option to the program to simulate the full trade protocol.  The bot will print
+ * your regtest trading peer's CLI commands will be printed on the console, for you to copy/paste into another terminal.
+ * <pre>
+ *     TakeBestPricedOfferToSellXmr  --password=api-password --port=api-port [--simulate-regtest-payment=true|false]
+ * </pre>
  */
 @Slf4j
 @Getter

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
@@ -48,7 +48,7 @@ import static protobuf.OfferDirection.BUY;
  *
  *          the offer's BTC amount is between 0.50 and 1.00 BTC
  *          the offer maker is one of two preferred trading peers
- *          the current transaction mining fee rate is below 15 sats / byte
+ *          the current transaction mining fee rate is less than or equal 15 sats / byte
  *
  *  The bot configurations for these rules are set in TakeBestPricedOfferToSellXmr.properties as follows:
  *

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
@@ -80,6 +80,8 @@ import static protobuf.OfferDirection.BUY;
  * <pre>
  *     TakeBestPricedOfferToSellXmr  --password=api-password --port=api-port [--simulate-regtest-payment=true|false]
  * </pre>
+ *
+ * @see <a href="https://github.com/bisq-network/bisq-api-reference/blob/make-proto-downloader-runnable-from-any-dir/java-examples/src/main/java/bisq/bots/Config.java">bisq.bots.Config.java</a>
  */
 @Slf4j
 @Getter

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
@@ -61,7 +61,7 @@ import static protobuf.OfferDirection.BUY;
  * </pre>
  * <b>Usage</b>
  * <p><br/>
- * You must encrypt your wallet password before running this bot.  If it is not already, you can use the CLI:
+ * You must encrypt your wallet password before running this bot.  If it is not already encrypted, you can use the CLI:
  * <pre>
  *     $ ./bisq-cli --password=xyz --port=9998 setwalletpassword --wallet-password="be careful"
  * </pre>

--- a/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
+++ b/java-examples/src/main/java/bisq/bots/TakeBestPricedOfferToSellXmr.java
@@ -76,7 +76,7 @@ import static protobuf.OfferDirection.BUY;
  * </pre>
  * If your API daemon is running on a local regtest network (with a trading peer), you can pass the
  * '--simulate-regtest-payment=true' option to the program to simulate the full trade protocol.  The bot will print
- * your regtest trading peer's CLI commands will be printed on the console, for you to copy/paste into another terminal.
+ * your regtest trading peer's CLI commands in the console, for you to copy/paste into another terminal.
  * <pre>
  *     TakeBestPricedOfferToSellXmr  --password=api-password --port=api-port [--simulate-regtest-payment=true|false]
  * </pre>
@@ -343,9 +343,9 @@ public class TakeBestPricedOfferToSellXmr extends AbstractBot {
                             : "N/A");
 
             if (offer.getUseMarketBasedPrice()) {
-                var marginPriceLabel = format("Is offer's price margin (%s%%) <= bot's max market price margin (%s%%)?",
-                        offer.getMarketPriceMarginPct(),
-                        maxMarketPriceMargin);
+                var marginPriceLabel = format("Is offer's margin based price (%s) <= bot's target price (%s)?",
+                        offer.getPrice() + " BTC",
+                        targetPrice + " BTC");
                 filterResultsByLabel.put(marginPriceLabel, isMarginLEMaxMarketPriceMargin.test(offer, maxMarketPriceMargin));
             } else {
                 var fixedPriceLabel = format("Is offer's fixed-price (%s) <= bot's target price (%s)?",

--- a/java-examples/src/main/resources/TakeBestPricedOfferToBuyBsq.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToBuyBsq.properties
@@ -19,6 +19,7 @@ maxAmount=0.90
 maxTxFeeRate=25
 #
 # Taker bot's list of preferred trading peers (their onion addresses).
+# Example:  preferred-address-1.onion:9999,preferred-address-2.onion:9999
 # If you do not want to constrict trading to preferred peers, comment this line out with a '#' character.
 preferredTradingPeers=localhost:8888
 #

--- a/java-examples/src/main/resources/TakeBestPricedOfferToBuyBsq.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToBuyBsq.properties
@@ -1,12 +1,12 @@
 # Maximum # of offers to take during one bot session.  When reached, bot will shut down (but not the API daemon).
-maxTakeOffers=50
+maxTakeOffers=5
 #
 # Minimum distance from 30-day average BSQ trade price.
 # Note:  all BSQ Swap offers have a fixed-price, but the bot uses a margin (%) of the 30-day price for comparison.
 minMarketPriceMargin=0.00
 #
 # Hard coded 30-day average BSQ trade price, used for development over regtest.
-regtest30DayAvgBsqPrice=0.00005
+regtest30DayAvgBsqPrice=0.00004
 #
 # Taker bot's min BTC amount to sell.  The candidate SELL BTC offer's amount must be >= minAmount BTC.
 minAmount=0.01
@@ -24,4 +24,4 @@ maxTxFeeRate=25
 preferredTradingPeers=localhost:8888
 #
 # Offer polling frequency must be >= 1s (1000ms) between each getoffers request.
-pollingInterval=30000
+pollingInterval=60000

--- a/java-examples/src/main/resources/TakeBestPricedOfferToBuyBtc.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToBuyBtc.properties
@@ -1,13 +1,11 @@
-#
 # Maximum # of offers to take during one bot session.  When reached, bot will shut down API daemon then itself.
-maxTakeOffers=1
+maxTakeOffers=5
 #
 # Taker bot's payment account id.  Only BUY BTC offers using the same payment method will be considered for taking.
-paymentAccountId=6e58f3d9-e7a3-4799-aa38-e28e624d79a3
+paymentAccountId=9f791b7b-9b34-4931-8c93-8e7b0dc71612
 #
 # Taker bot's min market price margin.  A candidate BUY BTC offer's price margin must be >= minMarketPriceMargin.
-#
-minMarketPriceMargin=0
+minMarketPriceMargin=-5.00
 #
 # Taker bot's min BTC amount to sell.  The candidate BUY offer's amount must be >= minAmount BTC.
 minAmount=0.01
@@ -23,6 +21,7 @@ maxTxFeeRate=25
 bisqTradeFeeCurrency=BSQ
 #
 # Taker bot's list of preferred trading peers (their onion addresses).
+# Example:  preferred-address-1.onion:9999,preferred-address-2.onion:9999
 # If you do not want to constrict trading to preferred peers, comment this line out with a '#' character.
 preferredTradingPeers=localhost:8888, \
   nysf2pknaaxfh26k42ego5mnfzpbozyi3nuoxdu745unvva4pvywffyd.onion:9999, \
@@ -35,4 +34,4 @@ preferredTradingPeers=localhost:8888, \
   x6x2o3m6rxhkfuf2v6lalbharf3whwvkts5rdn3jkhgieqvnq6mvdfyd.onion:9999
 #
 # Offer polling frequency must be >= 1s (1000ms) between each getoffers request.
-pollingInterval=20000
+pollingInterval=60000

--- a/java-examples/src/main/resources/TakeBestPricedOfferToBuyXmr.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToBuyXmr.properties
@@ -1,0 +1,28 @@
+# Maximum # of offers to take during one bot session.  When reached, bot will shut down (but not the API daemon).
+maxTakeOffers=50
+#
+# Taker bot's payment account id.  Only SELL BTC offers using the same payment method will be considered for taking.
+paymentAccountId=a15d0f15-e355-4b89-8322-e262097623ae
+#
+# Taker bot's min market price margin.  A candidate sell BTC offer's price margin must be >= minMarketPriceMargin.
+minMarketPriceMargin=0
+#
+# Taker bot's min BTC amount to sell.  The candidate SELL BTC offer's amount must be >= minAmount BTC.
+minAmount=0.01
+#
+# Taker bot's max BTC amount to sell.  The candidate SELL BTC offer's amount must be <= maxAmount BTC.
+maxAmount=0.90
+#
+# Taker bot's max acceptable transaction fee rate (sats / byte).
+# Regtest fee rates are from https://price.bisq.wiz.biz/getFees
+maxTxFeeRate=25
+#
+# Bisq trade fee currency code (BSQ or BTC).
+bisqTradeFeeCurrency=BSQ
+#
+# Taker bot's list of preferred trading peers (their onion addresses).
+# If you do not want to constrict trading to preferred peers, comment this line out with a '#' character.
+preferredTradingPeers=localhost:8888
+#
+# Offer polling frequency must be >= 1s (1000ms) between each getoffers request.
+pollingInterval=30000

--- a/java-examples/src/main/resources/TakeBestPricedOfferToBuyXmr.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToBuyXmr.properties
@@ -1,21 +1,21 @@
 # Maximum # of offers to take during one bot session.  When reached, bot will shut down (but not the API daemon).
-maxTakeOffers=50
+maxTakeOffers=5
 #
 # Taker bot's payment account id.  Only SELL BTC offers using the same payment method will be considered for taking.
-paymentAccountId=a15d0f15-e355-4b89-8322-e262097623ae
+paymentAccountId=f32546cd-bb47-4bce-acc8-5227a13e2516
 #
 # Taker bot's min market price margin.  A candidate sell BTC offer's price margin must be >= minMarketPriceMargin.
-minMarketPriceMargin=0
+minMarketPriceMargin=-5.00
 #
 # Taker bot's min BTC amount to sell.  The candidate SELL BTC offer's amount must be >= minAmount BTC.
 minAmount=0.01
 #
 # Taker bot's max BTC amount to sell.  The candidate SELL BTC offer's amount must be <= maxAmount BTC.
-maxAmount=0.90
+maxAmount=1.00
 #
 # Taker bot's max acceptable transaction fee rate (sats / byte).
 # Regtest fee rates are from https://price.bisq.wiz.biz/getFees
-maxTxFeeRate=25
+maxTxFeeRate=50
 #
 # Bisq trade fee currency code (BSQ or BTC).
 bisqTradeFeeCurrency=BSQ
@@ -25,4 +25,4 @@ bisqTradeFeeCurrency=BSQ
 preferredTradingPeers=localhost:8888
 #
 # Offer polling frequency must be >= 1s (1000ms) between each getoffers request.
-pollingInterval=30000
+pollingInterval=10000

--- a/java-examples/src/main/resources/TakeBestPricedOfferToBuyXmr.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToBuyXmr.properties
@@ -21,6 +21,7 @@ maxTxFeeRate=50
 bisqTradeFeeCurrency=BSQ
 #
 # Taker bot's list of preferred trading peers (their onion addresses).
+# Example:  preferred-address-1.onion:9999,preferred-address-2.onion:9999
 # If you do not want to constrict trading to preferred peers, comment this line out with a '#' character.
 preferredTradingPeers=localhost:8888
 #

--- a/java-examples/src/main/resources/TakeBestPricedOfferToSellBsq.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToSellBsq.properties
@@ -19,6 +19,7 @@ maxAmount=0.90
 maxTxFeeRate=25
 #
 # Taker bot's list of preferred trading peers (their onion addresses).
+# Example:  preferred-address-1.onion:9999,preferred-address-2.onion:9999
 # If you do not want to constrict trading to preferred peers, comment this line out with a '#' character.
 preferredTradingPeers=localhost:8888
 #

--- a/java-examples/src/main/resources/TakeBestPricedOfferToSellBsq.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToSellBsq.properties
@@ -1,12 +1,12 @@
 # Maximum # of offers to take during one bot session.  When reached, bot will shut down (but not the API daemon).
-maxTakeOffers=50
+maxTakeOffers=5
 #
 # Maximum distance from 30-day average BSQ trade price.
 # Note:  all BSQ Swap offers have a fixed-price, but the bot uses a margin (%) of the 30-day price for comparison.
-maxMarketPriceMargin=0.00
+maxMarketPriceMargin=-1.0
 #
 # Hard coded 30-day average BSQ trade price, used for development over regtest.
-regtest30DayAvgBsqPrice=0.00037
+regtest30DayAvgBsqPrice=0.00060
 #
 # Taker bot's min BTC amount to buy.  The candidate BUY BTC offer's amount must be >= minAmount BTC.
 minAmount=0.01
@@ -24,4 +24,4 @@ maxTxFeeRate=25
 preferredTradingPeers=localhost:8888
 #
 # Offer polling frequency must be >= 1s (1000ms) between each getoffers request.
-pollingInterval=30000
+pollingInterval=60000

--- a/java-examples/src/main/resources/TakeBestPricedOfferToSellBtc.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToSellBtc.properties
@@ -22,6 +22,7 @@ maxTxFeeRate=100
 bisqTradeFeeCurrency=BSQ
 #
 # Taker bot's list of preferred trading peers (their onion addresses).
+# Example:  preferred-address-1.onion:9999,preferred-address-2.onion:9999
 # If you do not want to constrict trading to preferred peers, comment this line out with a '#' character.
 preferredTradingPeers=localhost:8888, \
   nysf2pknaaxfh26k42ego5mnfzpbozyi3nuoxdu745unvva4pvywffyd.onion:9999, \

--- a/java-examples/src/main/resources/TakeBestPricedOfferToSellBtc.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToSellBtc.properties
@@ -1,12 +1,12 @@
 #
 # Maximum # of offers to take during one bot session.  When reached, bot will shut down API daemon then itself.
-maxTakeOffers=4
+maxTakeOffers=1
 #
 # Taker bot's payment account id.  Only SELL BTC offers using the same payment method will be considered for taking.
-paymentAccountId=6e58f3d9-e7a3-4799-aa38-e28e624d79a3
+paymentAccountId=09dbadfd-c2ff-4bf4-b8d7-1d63e11d0238
 #
 # Taker bot's max market price margin.  A candidate SELL BTC offer's price margin must be <= maxMarketPriceMargin.
-maxMarketPriceMargin=3.00
+maxMarketPriceMargin=0.00
 #
 # Taker bot's min BTC amount to buy.  The candidate SELL offer's amount must be >= minAmount BTC.
 minAmount=0.01
@@ -16,7 +16,7 @@ maxAmount=0.50
 #
 # Taker bot's max acceptable transaction fee rate (sats / byte).
 # Regtest fee rates are from https://price.bisq.wiz.biz/getFees
-maxTxFeeRate=100
+maxTxFeeRate=20
 #
 # Bisq trade fee currency code (BSQ or BTC).
 bisqTradeFeeCurrency=BSQ
@@ -35,4 +35,4 @@ preferredTradingPeers=localhost:8888, \
   x6x2o3m6rxhkfuf2v6lalbharf3whwvkts5rdn3jkhgieqvnq6mvdfyd.onion:9999
 #
 # Offer polling frequency must be >= 1s (1000ms) between each getoffers request.
-pollingInterval=20000
+pollingInterval=60000

--- a/java-examples/src/main/resources/TakeBestPricedOfferToSellXmr.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToSellXmr.properties
@@ -1,0 +1,28 @@
+# Maximum # of offers to take during one bot session.  When reached, bot will shut down (but not the API daemon).
+maxTakeOffers=1
+#
+# Taker bot's payment account id.  Only SELL BTC offers using the same payment method will be considered for taking.
+paymentAccountId=a15d0f15-e355-4b89-8322-e262097623ae
+#
+# Taker bot's max market price margin.  A candidate buy BTC offer's price margin must be <= maxMarketPriceMargin.
+maxMarketPriceMargin=1.10
+#
+# Taker bot's min BTC amount to buy.  The candidate buy BTC offer's amount must be >= minAmount BTC.
+minAmount=0.01
+#
+# Taker bot's max BTC amount to buy.  The candidate buy BTC offer's amount must be <= maxAmount BTC.
+maxAmount=0.90
+#
+# Taker bot's max acceptable transaction fee rate (sats / byte).
+# Regtest fee rates are from https://price.bisq.wiz.biz/getFees
+maxTxFeeRate=25
+#
+# Bisq trade fee currency code (BSQ or BTC).
+bisqTradeFeeCurrency=BSQ
+#
+# Taker bot's list of preferred trading peers (their onion addresses).
+# If you do not want to constrict trading to preferred peers, comment this line out with a '#' character.
+preferredTradingPeers=localhost:8888
+#
+# Offer polling frequency must be >= 1s (1000ms) between each getoffers request.
+pollingInterval=30000

--- a/java-examples/src/main/resources/TakeBestPricedOfferToSellXmr.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToSellXmr.properties
@@ -21,6 +21,7 @@ maxTxFeeRate=25
 bisqTradeFeeCurrency=BSQ
 #
 # Taker bot's list of preferred trading peers (their onion addresses).
+# Example:  preferred-address-1.onion:9999,preferred-address-2.onion:9999
 # If you do not want to constrict trading to preferred peers, comment this line out with a '#' character.
 preferredTradingPeers=localhost:8888
 #

--- a/java-examples/src/main/resources/TakeBestPricedOfferToSellXmr.properties
+++ b/java-examples/src/main/resources/TakeBestPricedOfferToSellXmr.properties
@@ -1,17 +1,17 @@
 # Maximum # of offers to take during one bot session.  When reached, bot will shut down (but not the API daemon).
-maxTakeOffers=1
+maxTakeOffers=2
 #
 # Taker bot's payment account id.  Only SELL BTC offers using the same payment method will be considered for taking.
-paymentAccountId=a15d0f15-e355-4b89-8322-e262097623ae
+paymentAccountId=fafeec6e-fb95-4ff5-a537-ea7e9d1ad683
 #
 # Taker bot's max market price margin.  A candidate buy BTC offer's price margin must be <= maxMarketPriceMargin.
-maxMarketPriceMargin=1.10
+maxMarketPriceMargin=1
 #
 # Taker bot's min BTC amount to buy.  The candidate buy BTC offer's amount must be >= minAmount BTC.
 minAmount=0.01
 #
 # Taker bot's max BTC amount to buy.  The candidate buy BTC offer's amount must be <= maxAmount BTC.
-maxAmount=0.90
+maxAmount=1.00
 #
 # Taker bot's max acceptable transaction fee rate (sats / byte).
 # Regtest fee rates are from https://price.bisq.wiz.biz/getFees
@@ -25,4 +25,4 @@ bisqTradeFeeCurrency=BSQ
 preferredTradingPeers=localhost:8888
 #
 # Offer polling frequency must be >= 1s (1000ms) between each getoffers request.
-pollingInterval=30000
+pollingInterval=60000

--- a/python-examples/README.md
+++ b/python-examples/README.md
@@ -8,7 +8,7 @@ is named for the RPC method call being demonstrated.
 
 The [bisq.bots](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/rpccalls) package
 contains some simple bots. Please do not run the Python bot examples on mainnet.
-See [warning](#bot-not-ready-for-mainnet).
+See [warning](#do-not-run-python-bot-examples-on-mainnet).
 
 The `run-setup.sh` script in this directory can install Python3 dependencies and example packages into a local venv.
 
@@ -27,7 +27,7 @@ high-throughput, high-performance system supporting atomic transactions. Care mu
 slow wallet updates on your disk, and Tor network latency. The API daemon enforces limits on request frequency via call
 rate metering, but you cannot assume bots can perform tasks as rapidly as the API daemon's call rate meters allow.
 
-### [Do Not Run Python Bot Examples On Mainnet](#bot-not-ready-for-mainnet)
+### [Do Not Run Python Bot Examples On Mainnet](#do-not-run-python-bot-examples-on-mainnet)
 
 The scripts in the [bisq.bots](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/bots)
 package should not be run on mainnet. They do not properly handle errors, and were written by a Python noob.

--- a/python-examples/README.md
+++ b/python-examples/README.md
@@ -3,8 +3,37 @@
 This subproject contains Python3 classes demonstrating API gRPC method calls, and some sample bots.
 
 Each class in
-the [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/rpccalls) package is
-named for the RPC method call being demonstrated.
+the [bisq.rpccalls](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/rpccalls) package
+is named for the RPC method call being demonstrated.
+
+The [bisq.bots](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/rpccalls) package
+contains some simple bots. Please do not run the Python bot examples on mainnet.
+See [warning](#bot-not-ready-for-mainnet).
 
 The `run-setup.sh` script in this directory can install Python3 dependencies and example packages into a local venv.
 
+## Risks, Warnings and Flaws
+
+### Never Run API Daemon and [Bisq GUI](https://bisq.network) On Same Host At Same Time
+
+The API daemon and the GUI share the same default wallet and connection ports. Beyond inevitable failures due to
+fighting over the wallet and ports, doing so will probably corrupt your wallet. Before starting the API daemon, make
+sure your GUI is shut down, and vice-versa. Please back up your mainnet wallet early and often with the GUI.
+
+### Go Slow (But Much Faster Than You Click Buttons In The GUI)
+
+[Bisq](https://bisq.network) was designed to respond to manual clicks in the user interface. It is not a
+high-throughput, high-performance system supporting atomic transactions. Care must be taken to avoid problems due to
+slow wallet updates on your disk, and Tor network latency. The API daemon enforces limits on request frequency via call
+rate metering, but you cannot assume bots can perform tasks as rapidly as the API daemon's call rate meters allow.
+
+### [Do Not Run Python Bot Examples On Mainnet](#bot-not-ready-for-mainnet)
+
+The scripts in the [bisq.bots](https://github.com/bisq-network/bisq-api-reference/tree/main/python-examples/bisq/bots)
+package should not be run on mainnet. They do not properly handle errors, and were written by a Python noob.
+
+The [Java Bot Examples](https://github.com/bisq-network/bisq-api-reference/blob/split-up-take-btc-offer-bots/java-examples/README.md)
+are intended to be run on mainnet. An experienced Python developer could port these examples to Python for running on
+mainnet, and offer them as a contribution to
+the [Bisq API Reference](https://github.com/bisq-network/bisq-api-reference)
+project. If accepted, they could be [compensated](https://bisq.wiki/Making_a_compensation_request).


### PR DESCRIPTION
- Big refactor
- Filled out class level javadocs
- Filled out READMEs

Code, configuration and documentation is simplified with this refactoring.    Two bots could do everything to take BTC/BSQ/XMR offers, but we want the script configs to be less complex, and the code more readable for people who aren't Java devs -- who might want to port them to other gRPC supported language bindings.

_Note: there are some README links pointing back to this `split-up-take-btc-offer-bots` branch.  They will be changed to point to the `main` branch when/if this PR is near approval._
